### PR TITLE
Add --draft option to create PR in draft mode

### DIFF
--- a/ghstack/__main__.py
+++ b/ghstack/__main__.py
@@ -50,6 +50,9 @@ def main() -> None:
             '--no-skip', action='store_true',
             help='Never skip pushing commits, even if the contents didn\'t change '
                  '(use this if you\'ve only updated the commit message).')
+        subparser.add_argument(
+            '--draft', action='store_true',
+            help='Create the pull request in draft mode (only if it has not already been created)')
 
     unlink = subparsers.add_parser('unlink')
     unlink.add_argument('COMMITS', nargs='*')
@@ -110,6 +113,7 @@ def main() -> None:
                 short=args.short,
                 force=args.force,
                 no_skip=args.no_skip,
+                draft=args.draft,
                 github_url=conf.github_url,
             )
         elif args.cmd == 'unlink':

--- a/ghstack/submit.py
+++ b/ghstack/submit.py
@@ -113,6 +113,7 @@ def main(msg: Optional[str],
          short: bool = False,
          force: bool = False,
          no_skip: bool = False,
+         draft: bool = False,
          github_url: str = "github.com",
          ) -> List[Optional[DiffMeta]]:
 
@@ -201,6 +202,7 @@ def main(msg: Optional[str],
                           short=short,
                           force=force,
                           no_skip=no_skip,
+                          draft=draft,
                           stack=list(reversed(stack)),
                           github_url=github_url)
     submitter.prepare_updates()
@@ -305,6 +307,9 @@ class Submitter(object):
     # Do not skip unchanged diffs
     no_skip: bool
 
+    # Create the PR in draft mode if it is going to be created (and not updated).
+    draft: bool
+
     # Github url (normally github.com)
     github_url: str
 
@@ -325,6 +330,7 @@ class Submitter(object):
             short: bool,
             force: bool,
             no_skip: bool,
+            draft: bool,
             github_url: str,):
         self.github = github
         self.sh = sh
@@ -345,6 +351,7 @@ class Submitter(object):
         self.short = short
         self.force = force
         self.no_skip = no_skip
+        self.draft = draft
         self.github_url = github_url
 
     def _default_title_and_body(self, commit: ghstack.diff.Diff,
@@ -596,6 +603,7 @@ Since we cannot proceed, ghstack will abort now.
             base=branch_base(self.username, ghnum),
             body=pr_body,
             maintainer_can_modify=True,
+            draft=self.draft,
         )
         number = r['number']
 


### PR DESCRIPTION
This PR adds a `--draft` command-line option that, if passed, creates PRs in draft mode. This means that reviewers will not be notified and the PR cannot be merged without marking it as "ready for review."