### PR TITLE
Make default branch name configurable

### DIFF
--- a/ghstack/__main__.py
+++ b/ghstack/__main__.py
@@ -99,6 +99,7 @@ def main() -> None:
             oauth_token=conf.github_oauth,
             proxy=conf.proxy,
             github_url=conf.github_url,
+            master_branch=conf.master_branch,
         )
 
         if args.cmd == 'rage':
@@ -121,6 +122,7 @@ def main() -> None:
                 commits=args.COMMITS,
                 sh=sh,
                 github_url=conf.github_url,
+                master_branch=conf.master_branch,
             )
         elif args.cmd == 'land':
             ghstack.land.main(

--- a/ghstack/__main__.py
+++ b/ghstack/__main__.py
@@ -99,7 +99,6 @@ def main() -> None:
             oauth_token=conf.github_oauth,
             proxy=conf.proxy,
             github_url=conf.github_url,
-            master_branch=conf.master_branch,
         )
 
         if args.cmd == 'rage':
@@ -116,6 +115,7 @@ def main() -> None:
                 no_skip=args.no_skip,
                 draft=args.draft,
                 github_url=conf.github_url,
+                master_branch=conf.master_branch,
                 remote_name=conf.remote_name,
             )
         elif args.cmd == 'unlink':
@@ -132,6 +132,7 @@ def main() -> None:
                 github=github,
                 sh=sh,
                 github_url=conf.github_url,
+                master_branch=conf.master_branch,
                 remote_name=conf.remote_name,
             )
         elif args.cmd == 'action':

--- a/ghstack/__main__.py
+++ b/ghstack/__main__.py
@@ -115,7 +115,7 @@ def main() -> None:
                 no_skip=args.no_skip,
                 draft=args.draft,
                 github_url=conf.github_url,
-                master_branch=conf.master_branch,
+                default_branch=conf.default_branch,
                 remote_name=conf.remote_name,
             )
         elif args.cmd == 'unlink':
@@ -123,7 +123,7 @@ def main() -> None:
                 commits=args.COMMITS,
                 sh=sh,
                 github_url=conf.github_url,
-                master_branch=conf.master_branch,
+                default_branch=conf.default_branch,
                 remote_name=conf.remote_name,
             )
         elif args.cmd == 'land':
@@ -132,7 +132,7 @@ def main() -> None:
                 github=github,
                 sh=sh,
                 github_url=conf.github_url,
-                master_branch=conf.master_branch,
+                default_branch=conf.default_branch,
                 remote_name=conf.remote_name,
             )
         elif args.cmd == 'action':

--- a/ghstack/config.py
+++ b/ghstack/config.py
@@ -18,6 +18,8 @@ Config = NamedTuple('Config', [
     ('github_username', str),
     # Token to authenticate to CircleCI with
     ('circle_token', Optional[str]),
+    # Name of master branch or equivalent
+    ('master_branch', str),
 
     # These config parameters are not used by ghstack, but other
     # tools that reuse this module
@@ -119,6 +121,10 @@ def read_config(*, request_circle_token: bool = False) -> Config:  # noqa: C901
             github_username)
         write_back = True
 
+    master_branch = 'master'
+    if config.has_option('ghstack', 'master_branch'):
+        master_branch = config.get('ghstack', 'master_branch')
+
     proxy = None
     if config.has_option('ghstack', 'proxy'):
         proxy = config.get('ghstack', 'proxy')
@@ -151,4 +157,5 @@ def read_config(*, request_circle_token: bool = False) -> Config:  # noqa: C901
         github_path=github_path,
         default_project_dir=default_project_dir,
         github_url=github_url,
+        master_branch=master_branch,
     )

--- a/ghstack/config.py
+++ b/ghstack/config.py
@@ -18,8 +18,8 @@ Config = NamedTuple('Config', [
     ('github_username', str),
     # Token to authenticate to CircleCI with
     ('circle_token', Optional[str]),
-    # Name of master branch or equivalent
-    ('master_branch', str),
+    # The repo's default branch
+    ('default_branch', str),
 
     # These config parameters are not used by ghstack, but other
     # tools that reuse this module
@@ -123,9 +123,9 @@ def read_config(*, request_circle_token: bool = False) -> Config:  # noqa: C901
             github_username)
         write_back = True
 
-    master_branch = 'master'
-    if config.has_option('ghstack', 'master_branch'):
-        master_branch = config.get('ghstack', 'master_branch')
+    default_branch = 'master'
+    if config.has_option('ghstack', 'default_branch'):
+        default_branch = config.get('ghstack', 'default_branch')
 
     proxy = None
     if config.has_option('ghstack', 'proxy'):
@@ -164,6 +164,6 @@ def read_config(*, request_circle_token: bool = False) -> Config:  # noqa: C901
         github_path=github_path,
         default_project_dir=default_project_dir,
         github_url=github_url,
-        master_branch=master_branch,
+        default_branch=default_branch,
         remote_name=remote_name,
     )

--- a/ghstack/github_real.py
+++ b/ghstack/github_real.py
@@ -39,12 +39,14 @@ class RealGitHubEndpoint(ghstack.github.GitHubEndpoint):
     def __init__(self,
                  oauth_token: str,
                  github_url: str,
+                 master_branch: str,
                  proxy: Optional[str] = None,
                  verify: Optional[str] = None,
                  cert: Optional[Union[str, Tuple[str, str]]] = None):
         self.oauth_token = oauth_token
         self.proxy = proxy
         self.github_url = github_url
+        self.master_branch = master_branch
         self.verify = verify
         self.cert = cert
 

--- a/ghstack/github_real.py
+++ b/ghstack/github_real.py
@@ -39,14 +39,12 @@ class RealGitHubEndpoint(ghstack.github.GitHubEndpoint):
     def __init__(self,
                  oauth_token: str,
                  github_url: str,
-                 master_branch: str,
                  proxy: Optional[str] = None,
                  verify: Optional[str] = None,
                  cert: Optional[Union[str, Tuple[str, str]]] = None):
         self.oauth_token = oauth_token
         self.proxy = proxy
         self.github_url = github_url
-        self.master_branch = master_branch
         self.verify = verify
         self.cert = cert
 

--- a/ghstack/land.py
+++ b/ghstack/land.py
@@ -40,6 +40,7 @@ def main(pull_request: str,
 
     params = ghstack.github_utils.parse_pull_request(pull_request)
     orig_ref = lookup_pr_to_orig_ref(github, **params)
+    master_branch = github.master_branch or "master"
 
     if sh is None:
         # Use CWD
@@ -48,7 +49,7 @@ def main(pull_request: str,
     # Get up-to-date
     sh.git("fetch", "origin")
     remote_orig_ref = "origin/" + orig_ref
-    base = GitCommitHash(sh.git("merge-base", "origin/master", remote_orig_ref))
+    base = GitCommitHash(sh.git("merge-base", f"origin/{master_branch}", remote_orig_ref))
 
     # compute the stack of commits in chronological order (does not
     # include base)
@@ -64,7 +65,7 @@ def main(pull_request: str,
         prev_ref = sh.git("rev-parse", "HEAD")
 
     # If this fails, we don't have to reset
-    sh.git("checkout", "origin/master")
+    sh.git("checkout", f"origin/{master_branch}")
 
     try:
         # Compute the metadata for each commit
@@ -89,7 +90,7 @@ def main(pull_request: str,
                 raise
 
         # All good! Push!
-        sh.git("push", "origin", "HEAD:refs/heads/master")
+        sh.git("push", "origin", f"HEAD:refs/heads/{master_branch}")
 
     finally:
         sh.git("checkout", prev_ref)

--- a/ghstack/land.py
+++ b/ghstack/land.py
@@ -29,7 +29,7 @@ def lookup_pr_to_orig_ref(github: ghstack.github.GitHubEndpoint, owner: str, nam
 
 
 def main(pull_request: str,
-         master_branch: str,
+         default_branch: str,
          remote_name: str,
          github: ghstack.github.GitHubEndpoint,
          sh: ghstack.shell.Shell,
@@ -50,7 +50,7 @@ def main(pull_request: str,
     # Get up-to-date
     sh.git("fetch", remote_name)
     remote_orig_ref = remote_name + "/" + orig_ref
-    base = GitCommitHash(sh.git("merge-base", f"{remote_name}/{master_branch}", remote_orig_ref))
+    base = GitCommitHash(sh.git("merge-base", f"{remote_name}/{default_branch}", remote_orig_ref))
 
     # compute the stack of commits in chronological order (does not
     # include base)
@@ -66,7 +66,7 @@ def main(pull_request: str,
         prev_ref = sh.git("rev-parse", "HEAD")
 
     # If this fails, we don't have to reset
-    sh.git("checkout", f"{remote_name}/{master_branch}")
+    sh.git("checkout", f"{remote_name}/{default_branch}")
 
     try:
         # Compute the metadata for each commit
@@ -91,7 +91,7 @@ def main(pull_request: str,
                 raise
 
         # All good! Push!
-        sh.git("push", remote_name, f"HEAD:refs/heads/{master_branch}")
+        sh.git("push", remote_name, f"HEAD:refs/heads/{default_branch}")
 
     finally:
         sh.git("checkout", prev_ref)

--- a/ghstack/land.py
+++ b/ghstack/land.py
@@ -29,6 +29,7 @@ def lookup_pr_to_orig_ref(github: ghstack.github.GitHubEndpoint, owner: str, nam
 
 
 def main(pull_request: str,
+         master_branch: str,
          remote_name: str,
          github: ghstack.github.GitHubEndpoint,
          sh: ghstack.shell.Shell,
@@ -41,7 +42,6 @@ def main(pull_request: str,
 
     params = ghstack.github_utils.parse_pull_request(pull_request)
     orig_ref = lookup_pr_to_orig_ref(github, **params)
-    master_branch = github.master_branch or "master"
 
     if sh is None:
         # Use CWD

--- a/ghstack/submit.py
+++ b/ghstack/submit.py
@@ -115,6 +115,7 @@ def main(msg: Optional[str],
          no_skip: bool = False,
          draft: bool = False,
          github_url: str = "github.com",
+         master_branch: str = "master",
          remote_name: str = "origin"
          ) -> List[Optional[DiffMeta]]:
 
@@ -174,7 +175,6 @@ def main(msg: Optional[str],
     repo_id = repo["id"]
 
     sh.git("fetch", remote_name)
-    master_branch = github.master_branch or "master"
     base = GitCommitHash(sh.git("merge-base", f"{remote_name}/{master_branch}", "HEAD"))
 
     # compute the stack of commits to process (reverse chronological order),

--- a/ghstack/submit.py
+++ b/ghstack/submit.py
@@ -115,7 +115,7 @@ def main(msg: Optional[str],
          no_skip: bool = False,
          draft: bool = False,
          github_url: str = "github.com",
-         master_branch: str = "master",
+         default_branch: str = "master",
          remote_name: str = "origin"
          ) -> List[Optional[DiffMeta]]:
 
@@ -175,7 +175,7 @@ def main(msg: Optional[str],
     repo_id = repo["id"]
 
     sh.git("fetch", remote_name)
-    base = GitCommitHash(sh.git("merge-base", f"{remote_name}/{master_branch}", "HEAD"))
+    base = GitCommitHash(sh.git("merge-base", f"{remote_name}/{default_branch}", "HEAD"))
 
     # compute the stack of commits to process (reverse chronological order),
     stack = ghstack.git.parse_header(

--- a/ghstack/submit.py
+++ b/ghstack/submit.py
@@ -172,7 +172,8 @@ def main(msg: Optional[str],
     repo_id = repo["id"]
 
     sh.git("fetch", "origin")
-    base = GitCommitHash(sh.git("merge-base", "origin/master", "HEAD"))
+    master_branch = github.master_branch or "master"
+    base = GitCommitHash(sh.git("merge-base", f"origin/{master_branch}", "HEAD"))
 
     # compute the stack of commits to process (reverse chronological order),
     stack = ghstack.git.parse_header(

--- a/ghstack/unlink.py
+++ b/ghstack/unlink.py
@@ -16,7 +16,8 @@ RE_GHSTACK_SOURCE_ID = re.compile(r'^ghstack-source-id: (.+)\n?', re.MULTILINE)
 
 def main(commits: Optional[List[str]] = None,
          sh: Optional[ghstack.shell.Shell] = None,
-         github_url: str = "github.com") -> GitCommitHash:
+         github_url: str = "github.com",
+         master_branch: str = "master") -> GitCommitHash:
     # If commits is empty, we unlink the entire stack
     #
     # For now, we only process commits on our current
@@ -34,7 +35,7 @@ def main(commits: Optional[List[str]] = None,
         for c in commits:
             parsed_commits.add(GitCommitHash(sh.git("rev-parse", c)))
 
-    base = GitCommitHash(sh.git("merge-base", "origin/master", "HEAD"))
+    base = GitCommitHash(sh.git("merge-base", f"origin/{master_branch}", "HEAD"))
 
     # compute the stack of commits in chronological order (does not
     # include base)

--- a/ghstack/unlink.py
+++ b/ghstack/unlink.py
@@ -17,7 +17,7 @@ RE_GHSTACK_SOURCE_ID = re.compile(r'^ghstack-source-id: (.+)\n?', re.MULTILINE)
 def main(commits: Optional[List[str]] = None,
          sh: Optional[ghstack.shell.Shell] = None,
          github_url: str = "github.com",
-         master_branch: str = "master",
+         default_branch: str = "master",
          remote_name: str = "origin") -> GitCommitHash:
     # If commits is empty, we unlink the entire stack
     #
@@ -36,7 +36,7 @@ def main(commits: Optional[List[str]] = None,
         for c in commits:
             parsed_commits.add(GitCommitHash(sh.git("rev-parse", c)))
 
-    base = GitCommitHash(sh.git("merge-base", f"{remote_name}/{master_branch}", "HEAD"))
+    base = GitCommitHash(sh.git("merge-base", f"{remote_name}/{default_branch}", "HEAD"))
 
     # compute the stack of commits in chronological order (does not
     # include base)

--- a/test_ghstack.py
+++ b/test_ghstack.py
@@ -115,6 +115,7 @@ class TestGh(expecttest.TestCase):
 
     def gh_land(self, pull_request: str) -> None:
         return ghstack.land.main(
+            master_branch='master',
             remote_name='origin',
             pull_request=pull_request,
             github=self.github,

--- a/test_ghstack.py
+++ b/test_ghstack.py
@@ -115,7 +115,7 @@ class TestGh(expecttest.TestCase):
 
     def gh_land(self, pull_request: str) -> None:
         return ghstack.land.main(
-            master_branch='master',
+            master_branch='default_branch',
             remote_name='origin',
             pull_request=pull_request,
             github=self.github,

--- a/test_ghstack.py
+++ b/test_ghstack.py
@@ -115,7 +115,7 @@ class TestGh(expecttest.TestCase):
 
     def gh_land(self, pull_request: str) -> None:
         return ghstack.land.main(
-            master_branch='default_branch',
+            default_branch='master',
             remote_name='origin',
             pull_request=pull_request,
             github=self.github,


### PR DESCRIPTION
At my company, the master branch is `dev`, so ghstack doesn't work great out of the box. To make it work for me, I made the master branch's name a config option!

How I tested this:
* I added `default_branch = dev` to my `~/.ghstackrc`
* Rebased my stack of commits on `dev`
* Ran `ghstack` and it worked!