### PR TITLE
Make remote name configurable instead of assuming origin

### DIFF
--- a/ghstack/__main__.py
+++ b/ghstack/__main__.py
@@ -115,12 +115,14 @@ def main() -> None:
                 no_skip=args.no_skip,
                 draft=args.draft,
                 github_url=conf.github_url,
+                remote_name=conf.remote_name,
             )
         elif args.cmd == 'unlink':
             ghstack.unlink.main(
                 commits=args.COMMITS,
                 sh=sh,
                 github_url=conf.github_url,
+                remote_name=conf.remote_name,
             )
         elif args.cmd == 'land':
             ghstack.land.main(
@@ -128,6 +130,7 @@ def main() -> None:
                 github=github,
                 sh=sh,
                 github_url=conf.github_url,
+                remote_name=conf.remote_name,
             )
         elif args.cmd == 'action':
             ghstack.action.main(
@@ -155,7 +158,12 @@ def main() -> None:
             ))
             loop.close()
         elif args.cmd == 'checkout':
-            ghstack.checkout.main(pull_request=args.pull_request, github=github, sh=sh)
+            ghstack.checkout.main(
+                pull_request=args.pull_request,
+                github=github,
+                sh=sh,
+                remote_name=conf.remote_name,
+            )
         else:
             raise RuntimeError("Unrecognized command {}".format(args.cmd))
 

--- a/ghstack/checkout.py
+++ b/ghstack/checkout.py
@@ -11,6 +11,7 @@ import re
 def main(pull_request: str,
          github: ghstack.github.GitHubEndpoint,
          sh: ghstack.shell.Shell,
+         remote_name: str,
          ) -> None:
 
     params = ghstack.github_utils.parse_pull_request(pull_request)
@@ -30,5 +31,5 @@ def main(pull_request: str,
 
     # TODO: Handle remotes correctly too (so this subsumes hub)
 
-    sh.git("fetch", "origin")
-    sh.git("checkout", "origin/" + orig_ref)
+    sh.git("fetch", remote_name)
+    sh.git("checkout", remote_name + "/" + orig_ref)

--- a/ghstack/config.py
+++ b/ghstack/config.py
@@ -31,7 +31,9 @@ Config = NamedTuple('Config', [
     # autodetection fails
     ('default_project_dir', str),
     # GitHub url. Defaults to github.com which is true for all non-enterprise github repos
-    ('github_url', str)
+    ('github_url', str),
+    # Name of the upstream remote
+    ('remote_name', str)
 ])
 
 
@@ -138,6 +140,11 @@ def read_config(*, request_circle_token: bool = False) -> Config:  # noqa: C901
     else:
         default_project_dir = 'fbcode/caffe2'
 
+    if config.has_option('ghstack', 'remote_name'):
+        remote_name = config.get('ghstack', 'remote_name')
+    else:
+        remote_name = 'origin'
+
     if write_back:
         config.write(open(config_path, 'w'))
         logging.info("NB: configuration saved to {}".format(config_path))
@@ -151,4 +158,5 @@ def read_config(*, request_circle_token: bool = False) -> Config:  # noqa: C901
         github_path=github_path,
         default_project_dir=default_project_dir,
         github_url=github_url,
+        remote_name=remote_name,
     )

--- a/ghstack/unlink.py
+++ b/ghstack/unlink.py
@@ -16,7 +16,8 @@ RE_GHSTACK_SOURCE_ID = re.compile(r'^ghstack-source-id: (.+)\n?', re.MULTILINE)
 
 def main(commits: Optional[List[str]] = None,
          sh: Optional[ghstack.shell.Shell] = None,
-         github_url: str = "github.com") -> GitCommitHash:
+         github_url: str = "github.com",
+         remote_name: str = "origin") -> GitCommitHash:
     # If commits is empty, we unlink the entire stack
     #
     # For now, we only process commits on our current
@@ -34,7 +35,7 @@ def main(commits: Optional[List[str]] = None,
         for c in commits:
             parsed_commits.add(GitCommitHash(sh.git("rev-parse", c)))
 
-    base = GitCommitHash(sh.git("merge-base", "origin/master", "HEAD"))
+    base = GitCommitHash(sh.git("merge-base", remote_name + "/master", "HEAD"))
 
     # compute the stack of commits in chronological order (does not
     # include base)

--- a/test_ghstack.py
+++ b/test_ghstack.py
@@ -115,6 +115,7 @@ class TestGh(expecttest.TestCase):
 
     def gh_land(self, pull_request: str) -> None:
         return ghstack.land.main(
+            remote_name='origin',
             pull_request=pull_request,
             github=self.github,
             sh=self.sh,


### PR DESCRIPTION
I like to use "upstream" for the main repo and point "origin" to my fork. 