### PR TITLE
relax checkout PR url regex

### DIFF
--- a/ghstack/github_utils.py
+++ b/ghstack/github_utils.py
@@ -12,7 +12,7 @@ except ImportError:
 
 
 RE_PR_URL = re.compile(
-    r'^https://github\.com/(?P<owner>[^/]+)/(?P<name>[^/]+)/pull/(?P<number>[0-9]+)/?$')
+    r'^(https://github\.com/)?(/)?(?P<owner>[^/]+)/(?P<name>[^/]+)/pull/(?P<number>[0-9]+)/?$')
 
 GitHubPullRequestParams = TypedDict('GitHubPullRequestParams', {
     'owner': str,

--- a/ghstack/github_utils.py
+++ b/ghstack/github_utils.py
@@ -12,9 +12,10 @@ except ImportError:
 
 
 RE_PR_URL = re.compile(
-    r'^https://([^/]+)/(?P<owner>[^/]+)/(?P<name>[^/]+)/pull/(?P<number>[0-9]+)/?$')
+    r'^https://(?P<github_url>[^/]+)/(?P<owner>[^/]+)/(?P<name>[^/]+)/pull/(?P<number>[0-9]+)/?$')
 
 GitHubPullRequestParams = TypedDict('GitHubPullRequestParams', {
+    'github_url': str
     'owner': str,
     'name': str,
     'number': int,
@@ -26,7 +27,8 @@ def parse_pull_request(pull_request: str) -> GitHubPullRequestParams:
     if not m:
         raise RuntimeError("Did not understand PR argument.  PR must be URL")
 
+    github_url = m.group("github_url")
     owner = m.group("owner")
     name = m.group("name")
     number = int(m.group("number"))
-    return {'owner': owner, 'name': name, 'number': number}
+    return {'github_url': github_url, 'owner': owner, 'name': name, 'number': number}

--- a/ghstack/github_utils.py
+++ b/ghstack/github_utils.py
@@ -12,7 +12,7 @@ except ImportError:
 
 
 RE_PR_URL = re.compile(
-    r'^(https://github\.com/)?(/)?(?P<owner>[^/]+)/(?P<name>[^/]+)/pull/(?P<number>[0-9]+)/?$')
+    r'^https://([^/])/(?P<owner>[^/]+)/(?P<name>[^/]+)/pull/(?P<number>[0-9]+)/?$')
 
 GitHubPullRequestParams = TypedDict('GitHubPullRequestParams', {
     'owner': str,

--- a/ghstack/github_utils.py
+++ b/ghstack/github_utils.py
@@ -12,7 +12,7 @@ except ImportError:
 
 
 RE_PR_URL = re.compile(
-    r'^https://([^/])/(?P<owner>[^/]+)/(?P<name>[^/]+)/pull/(?P<number>[0-9]+)/?$')
+    r'^https://([^/]+)/(?P<owner>[^/]+)/(?P<name>[^/]+)/pull/(?P<number>[0-9]+)/?$')
 
 GitHubPullRequestParams = TypedDict('GitHubPullRequestParams', {
     'owner': str,


### PR DESCRIPTION
https://github.com/ezyang/ghstack/pull/13 added custom GitHub URL. But the change didn't wasn't applied to checkout.

I relaxed the PR URL regex a bit. I could also pass down the custom URL from the `github` object [here](https://github.com/ezyang/ghstack/blob/master/ghstack/checkout.py#L17) if you think that's a better approach.