### PR TITLE
Don't constrain Flake8 and mypy to specific files

### DIFF
--- a/detailed-mypy.ini
+++ b/detailed-mypy.ini
@@ -2,6 +2,7 @@
 python_version = 3.7
 strict_optional = True
 show_column_numbers = True
+show_error_codes = True
 warn_no_return = True
 disallow_any_unimported = True
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,7 +3,7 @@ set -ex
 # NB: must not apply detailed-mypy.ini to flake8, because
 # flake8 runs mypy on each file individually which means types
 # from imported things won't get processed correctly
-flake8 ghstack
-mypy --config=detailed-mypy.ini ghstack test_ghstack.py
+flake8
+mypy --config=detailed-mypy.ini .
 pytest --verbose
 echo "OK"

--- a/test_ghstack.py
+++ b/test_ghstack.py
@@ -9,7 +9,7 @@ import sys
 import contextlib
 import io
 
-from typing import ClassVar, Dict, NewType, List, Tuple, Iterator, Optional
+from typing import Dict, NewType, List, Tuple, Iterator, Optional
 
 import ghstack.expecttest as expecttest
 

--- a/test_shell.py
+++ b/test_shell.py
@@ -45,7 +45,7 @@ class TestShell(expecttest.TestCase):
                 args.extend(('r', '-'))
         return self.sh.sh(*args, **kwargs)
 
-    def flog(self, cm: 'unittest._AssertLogsContext') -> str:
+    def flog(self, cm: 'unittest._AssertLogsContext') -> str:  # type: ignore[name-defined]
         def redact(s: str) -> str:
             s = s.replace(sys.executable, 'python')
             return s


### PR DESCRIPTION
This PR makes the linting/typechecking more declarative and thus easier to integrate with editors like VS Code that run Flake8 and `mypy` on individual files (so we avoid [this situation](https://github.com/pytorch/pytorch/pull/50826)); for instance, this `.vscode/settings.json` now works:
```json
{
  "python.venvPath": "~/Library/Caches/pypoetry/virtualenvs",
  "python.pythonPath": "~/Library/Caches/pypoetry/virtualenvs/ghstack-RjXx9-bl-py3.6/bin/python",
  "python.linting.enabled": true,
  "python.linting.flake8Enabled": true,
  "python.linting.mypyEnabled": true,
  "python.linting.mypyArgs": [
    "--config-file=detailed-mypy.ini"
  ]
}
```
I also enabled `show_error_codes` to make it easier to add scoped `# type: ignore` comments (such as the one added to `test_shell.py` in this PR).