### PR TITLE
Don't hardcode master as much

### DIFF
--- a/ghstack/config.py
+++ b/ghstack/config.py
@@ -130,9 +130,18 @@ def read_config(*, request_circle_token: bool = False) -> Config:  # noqa: C901
             github_username)
         write_back = True
 
-    default_branch = 'master'
     if config.has_option('ghstack', 'default_branch'):
         default_branch = config.get('ghstack', 'default_branch')
+    else:
+        default_branch = input('Default branch [master]: ')
+        if not default_branch:
+            default_branch = 'master'
+        config.set(
+            'ghstack',
+            'default_branch',
+            default_branch
+        )
+        write_back = True
 
     proxy = None
     if config.has_option('ghstack', 'proxy'):

--- a/ghstack/submit.py
+++ b/ghstack/submit.py
@@ -105,6 +105,7 @@ class DiffWithGitHubMetadata:
 
 
 def main(msg: Optional[str],
+         *,
          username: str,
          github: ghstack.github.GitHubEndpoint,
          update_fields: bool = False,
@@ -116,9 +117,9 @@ def main(msg: Optional[str],
          force: bool = False,
          no_skip: bool = False,
          draft: bool = False,
-         github_url: str = "github.com",
-         default_branch: str = "master",
-         remote_name: str = "origin"
+         github_url: str,
+         default_branch: str,
+         remote_name: str
          ) -> List[Optional[DiffMeta]]:
 
     if sh is None:

--- a/ghstack/unlink.py
+++ b/ghstack/unlink.py
@@ -14,11 +14,12 @@ from typing import Set, List, Optional
 RE_GHSTACK_SOURCE_ID = re.compile(r'^ghstack-source-id: (.+)\n?', re.MULTILINE)
 
 
-def main(commits: Optional[List[str]] = None,
+def main(*,
+         commits: Optional[List[str]] = None,
          sh: Optional[ghstack.shell.Shell] = None,
-         github_url: str = "github.com",
-         default_branch: str = "master",
-         remote_name: str = "origin") -> GitCommitHash:
+         github_url: str,
+         default_branch: str,
+         remote_name: str) -> GitCommitHash:
     # If commits is empty, we unlink the entire stack
     #
     # For now, we only process commits on our current

--- a/test_ghstack.py
+++ b/test_ghstack.py
@@ -111,7 +111,10 @@ class TestGh(expecttest.TestCase):
             repo_owner='pytorch',
             repo_name='pytorch',
             short=short,
-            no_skip=no_skip)
+            no_skip=no_skip,
+            github_url='github.com',
+            default_branch='master',
+            remote_name='origin')
 
     def gh_land(self, pull_request: str) -> None:
         return ghstack.land.main(
@@ -126,7 +129,10 @@ class TestGh(expecttest.TestCase):
     # TODO: pass arguments
     def gh_unlink(self) -> None:
         ghstack.unlink.main(
-            sh=self.sh
+            sh=self.sh,
+            github_url='github.com',
+            default_branch='master',
+            remote_name='origin',
         )
 
     def dump_github(self) -> str:


### PR DESCRIPTION
Resolves #35.

This PR doesn't remove all instances of `master` from the codebase; rather, it just fixes a couple minor issues:

- The `main` functions in `ghstack.submit` and `ghstack.unlink` previously specified default values for some of their arguments that duplicated the default values already defined in `ghstack.config`, so now they require values to always be passed for those arguments.
- As mentioned in the issue thread, GitHub now names the default branch `main` for new repos, so `ghstack` would previously just fail when used on such a repo. Now it asks the user for the default branch if it's not already set in the config, similar to what it does for `github_url`.