### PR TITLE
Quote logged shell command args where necessary

### DIFF
--- a/ghstack/shell.py
+++ b/ghstack/shell.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import os
+import shlex
 import subprocess
 import sys
 from typing import (IO, Any, Dict, Optional, Sequence, Tuple, TypeVar, Union,
@@ -25,9 +26,7 @@ def log_command(args: Sequence[str]) -> None:
         *args: the list of command line arguments you want to run
         env: the dictionary of environment variable settings for the command
     """
-    # TODO: Irritatingly, this doesn't insert quotes for shell
-    # metacharacters like exclamation marks or parentheses.
-    cmd = subprocess.list2cmdline(args).replace("\n", "\\n")
+    cmd = ' '.join(shlex.quote(arg) for arg in args)
     logging.info("$ " + cmd)
 
 

--- a/test_shell.py
+++ b/test_shell.py
@@ -57,7 +57,7 @@ class TestShell(expecttest.TestCase):
                 out("arf\n")
             )
         self.assertExpected(self.flog(cm), '''\
-$ python emitter.py o arf\\n
+$ python emitter.py o 'arf\n'
 arf
 ''')
 
@@ -67,7 +67,7 @@ arf
                 err("arf\n")
             )
         self.assertExpected(self.flog(cm), '''\
-$ python emitter.py e arf\\n
+$ python emitter.py e 'arf\n'
 # stderr:
 arf
 ''')
@@ -79,7 +79,7 @@ arf
                 stdout=None
             )
         self.assertExpected(self.flog(cm), '''\
-$ python emitter.py o arf\\n
+$ python emitter.py o 'arf\n'
 arf
 ''')
 
@@ -94,7 +94,7 @@ arf
                 stdout=None
             )
         self.assertExpected(self.flog(cm), '''\
-$ python emitter.py e "Step 1...\\n" e "Step 2...\\n" e "Step 3...\\n" o out\\n
+$ python emitter.py e 'Step 1...\n' e 'Step 2...\n' e 'Step 3...\n' o 'out\n'
 # stderr:
 Step 1...
 Step 2...
@@ -115,7 +115,7 @@ out
                 stdout=None
             )
         self.assertExpected(self.flog(cm), '''\
-$ python emitter.py o A\\n e B\\n o C\\n e D\\n
+$ python emitter.py o 'A\n' e 'B\n' o 'C\n' e 'D\n'
 # stderr:
 B
 D


### PR DESCRIPTION
This PR makes `ghstack` always print logged commands in a form that can be copied and pasted directly into a shell. For example, previously `ghstack` would print commands like this:
```
$ git for-each-ref refs/remotes/origin/gh/samestep --format=%(refname)
```
Running the above in `zsh` gives this error message:
```
zsh: missing end of string
```
With this PR, `ghstack` instead prints this, which works properly:
```
$ git for-each-ref refs/remotes/origin/gh/samestep '--format=%(refname)'
```
As shown in this example, only the args that actually need quoting are quoted, so no unnecessary noise is added.

One possible downside is that now `log_command` prints any newlines as literal newlines (albeit in quotes), e.g. in `test_shell.py`. However, this seems better than the previous behavior, which would log this command for `test_interleaved_stdout_stderr_passthru`:
```
$ python emitter.py o A\\n e B\\n o C\\n e D\\n
```
The above prints this (with no trailing newline), which is incorrect:
```
AnBnCnDn
```
While printing a single command across multiple lines doesn't look great, the only other ways I could find to encode newlines in shell commands were these, neither of which are as easily implemented as just using `shlex.quote`:

- `echo` or `printf` along with piping or command substitution
- [ANSI-C quoting](https://www.gnu.org/software/bash/manual/html_node/ANSI_002dC-Quoting.html)