### PR TITLE
Fetch default branch from GitHub API

### DIFF
--- a/ghstack/__main__.py
+++ b/ghstack/__main__.py
@@ -114,6 +114,7 @@ def main() -> None:
         elif args.cmd == 'unlink':
             ghstack.unlink.main(
                 commits=args.COMMITS,
+                github=github,
                 sh=sh,
                 github_url=conf.github_url,
                 remote_name=conf.remote_name,

--- a/ghstack/__main__.py
+++ b/ghstack/__main__.py
@@ -109,7 +109,6 @@ def main() -> None:
                 no_skip=args.no_skip,
                 draft=args.draft,
                 github_url=conf.github_url,
-                default_branch=conf.default_branch,
                 remote_name=conf.remote_name,
             )
         elif args.cmd == 'unlink':
@@ -117,7 +116,6 @@ def main() -> None:
                 commits=args.COMMITS,
                 sh=sh,
                 github_url=conf.github_url,
-                default_branch=conf.default_branch,
                 remote_name=conf.remote_name,
             )
         elif args.cmd == 'land':
@@ -126,7 +124,6 @@ def main() -> None:
                 github=github,
                 sh=sh,
                 github_url=conf.github_url,
-                default_branch=conf.default_branch,
                 remote_name=conf.remote_name,
             )
         elif args.cmd == 'action':

--- a/ghstack/config.py
+++ b/ghstack/config.py
@@ -19,8 +19,6 @@ Config = NamedTuple('Config', [
     ('github_username', str),
     # Token to authenticate to CircleCI with
     ('circle_token', Optional[str]),
-    # The repo's default branch
-    ('default_branch', str),
 
     # These config parameters are not used by ghstack, but other
     # tools that reuse this module
@@ -129,19 +127,6 @@ def read_config(*, request_circle_token: bool = False) -> Config:  # noqa: C901
             github_username)
         write_back = True
 
-    if config.has_option('ghstack', 'default_branch'):
-        default_branch = config.get('ghstack', 'default_branch')
-    else:
-        default_branch = input('Default branch [master]: ')
-        if not default_branch:
-            default_branch = 'master'
-        config.set(
-            'ghstack',
-            'default_branch',
-            default_branch
-        )
-        write_back = True
-
     proxy = None
     if config.has_option('ghstack', 'proxy'):
         proxy = config.get('ghstack', 'proxy')
@@ -179,7 +164,6 @@ def read_config(*, request_circle_token: bool = False) -> Config:  # noqa: C901
         github_path=github_path,
         default_project_dir=default_project_dir,
         github_url=github_url,
-        default_branch=default_branch,
         remote_name=remote_name,
     )
     logging.debug(f"conf = {conf}")

--- a/ghstack/github_fake.py
+++ b/ghstack/github_fake.py
@@ -363,6 +363,7 @@ class FakeGitHubEndpoint(ghstack.github.GitHubEndpoint):
                         cast(UpdatePullRequestInput, kwargs))
                 elif 'default_branch' in kwargs:
                     return self._set_default_branch(
+                        owner, name,
                         cast(SetDefaultBranchInput, kwargs))
         raise NotImplementedError(
             "FakeGitHubEndpoint REST {} {} not implemented"

--- a/ghstack/github_fake.py
+++ b/ghstack/github_fake.py
@@ -15,6 +15,12 @@ GraphQLId = NewType('GraphQLId', str)
 GitHubNumber = NewType('GitHubNumber', int)
 GitObjectID = NewType('GitObjectID', str)
 
+# https://stackoverflow.com/a/55250601
+SetDefaultBranchInput = TypedDict('SetDefaultBranchInput', {
+    'name': str,
+    'default_branch': str,
+})
+
 UpdatePullRequestInput = TypedDict('UpdatePullRequestInput', {
     'base': Optional[str],
     'title': Optional[str],
@@ -86,12 +92,14 @@ class GitHubState:
         self.root = Root()
 
         # Populate it with the most important repo ;)
-        self.repositories[GraphQLId("1000")] = Repository(
+        repo = Repository(
             id=GraphQLId("1000"),
             name="pytorch",
             nameWithOwner="pytorch/pytorch",
             isFork=False,
+            defaultBranchRef=None,
         )
+        self.repositories[GraphQLId("1000")] = repo
         self._next_pull_request_number[GraphQLId("1000")] = 500
 
         self.upstream_sh = upstream_sh
@@ -109,6 +117,12 @@ class GitHubState:
                 tree,
                 input="Initial commit")
             self.upstream_sh.git("branch", "-f", "master", commit)
+
+            # We only update this when a PATCH changes the default
+            # branch; hopefully that's fine?  In any case, it should
+            # work for now since currently we only ever access the name
+            # of the default branch rather than other parts of its ref.
+            repo.defaultBranchRef = repo._make_ref(self, "master")
 
 
 @dataclass
@@ -130,6 +144,7 @@ class Repository(Node):
     name: str
     nameWithOwner: str
     isFork: bool
+    defaultBranchRef: Optional['Ref']
 
     def pullRequest(self,
                     info: GraphQLResolveInfo,
@@ -272,8 +287,6 @@ class FakeGitHubEndpoint(ghstack.github.GitHubEndpoint):
     def push_hook(self, refNames: Sequence[str]) -> None:
         self.state.push_hook(refNames)
 
-    # NB: This technically does have a payload, but we don't
-    # use it so I didn't bother constructing it.
     def _create_pull(self, owner: str, name: str,
                      input: CreatePullRequestInput) -> CreatePullRequestPayload:
         state = self.state
@@ -326,6 +339,14 @@ class FakeGitHubEndpoint(ghstack.github.GitHubEndpoint):
         if 'body' in input and input['body'] is not None:
             pr.body = input['body']
 
+    # NB: This may have a payload, but we don't
+    # use it so I didn't bother constructing it.
+    def _set_default_branch(self, owner: str, name: str,
+                            input: SetDefaultBranchInput) -> None:
+        state = self.state
+        repo = state.repository(owner, name)
+        repo.defaultBranchRef = repo._make_ref(state, input['default_branch'])
+
     def rest(self, method: str, path: str, **kwargs: Any) -> Any:
         if method == 'post':
             m = re.match(r'^repos/([^/]+)/([^/]+)/pulls$', path)
@@ -333,11 +354,16 @@ class FakeGitHubEndpoint(ghstack.github.GitHubEndpoint):
                 return self._create_pull(m.group(1), m.group(2),
                                          cast(CreatePullRequestInput, kwargs))
         elif method == 'patch':
-            m = re.match(r'^repos/([^/]+)/([^/]+)/pulls/([^/]+)$', path)
+            m = re.match(r'^repos/([^/]+)/([^/]+)(?:/pulls/([^/]+))?$', path)
             if m:
-                return self._update_pull(
-                    m.group(1), m.group(2), GitHubNumber(int(m.group(3))),
-                    cast(UpdatePullRequestInput, kwargs))
+                owner, name, number = m.groups()
+                if number is not None:
+                    return self._update_pull(
+                        owner, name, GitHubNumber(int(number)),
+                        cast(UpdatePullRequestInput, kwargs))
+                elif 'default_branch' in kwargs:
+                    return self._set_default_branch(
+                        cast(SetDefaultBranchInput, kwargs))
         raise NotImplementedError(
             "FakeGitHubEndpoint REST {} {} not implemented"
             .format(method.upper(), path)

--- a/ghstack/github_utils.py
+++ b/ghstack/github_utils.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 
 import re
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+import ghstack.github
+import ghstack.shell
+from ghstack.typing import GitHubRepositoryId
 
 try:
     from mypy_extensions import TypedDict
@@ -10,6 +14,92 @@ except ImportError:
     # It is required, however, for type checking.
     def TypedDict(name, attrs, total=True):  # type: ignore
         return Dict[Any, Any]
+
+
+GitHubRepoNameWithOwner = TypedDict('GitHubRepoNameWithOwner', {
+    'owner': str,
+    'name': str,
+})
+
+
+def get_github_repo_name_with_owner(
+    *,
+    sh: ghstack.shell.Shell,
+    github_url: str,
+    remote_name: str,
+) -> GitHubRepoNameWithOwner:
+    # Grovel in remotes to figure it out
+    remote_url = sh.git("remote", "get-url", remote_name)
+    while True:
+        match = r'^git@{github_url}:([^/]+)/([^.]+)(?:\.git)?$'.format(
+            github_url=github_url
+        )
+        m = re.match(match, remote_url)
+        if m:
+            owner = m.group(1)
+            name = m.group(2)
+            break
+        search = r'{github_url}/([^/]+)/([^.]+)'.format(
+            github_url=github_url
+        )
+        m = re.search(search, remote_url)
+        if m:
+            owner = m.group(1)
+            name = m.group(2)
+            break
+        raise RuntimeError(
+            "Couldn't determine repo owner and name from url: {}"
+            .format(remote_url))
+    return {'owner': owner, 'name': name}
+
+
+GitHubRepoInfo = TypedDict('GitHubRepoInfo', {
+    'name_with_owner': GitHubRepoNameWithOwner,
+    'id': GitHubRepositoryId,
+    'is_fork': bool,
+    'default_branch': str,
+})
+
+
+def get_github_repo_info(
+    *,
+    github: ghstack.github.GitHubEndpoint,
+    sh: ghstack.shell.Shell,
+    repo_owner: Optional[str] = None,
+    repo_name: Optional[str] = None,
+    github_url: str,
+    remote_name: str,
+) -> GitHubRepoInfo:
+    if repo_owner is None or repo_name is None:
+        name_with_owner = get_github_repo_name_with_owner(
+            sh=sh,
+            github_url=github_url,
+            remote_name=remote_name,
+        )
+    else:
+        name_with_owner = {"owner": repo_owner, "name": repo_name}
+
+    # TODO: Cache this guy
+    repo = github.graphql(
+        """
+        query ($owner: String!, $name: String!) {
+            repository(name: $name, owner: $owner) {
+                id
+                isFork
+                defaultBranchRef {
+                    name
+                }
+            }
+        }""",
+        owner=name_with_owner["owner"],
+        name=name_with_owner["name"])["data"]["repository"]
+
+    return {
+        "name_with_owner": name_with_owner,
+        "id": repo["id"],
+        "is_fork": repo["isFork"],
+        "default_branch": repo["defaultBranchRef"]["name"],
+    }
 
 
 RE_PR_URL = re.compile(

--- a/ghstack/submit.py
+++ b/ghstack/submit.py
@@ -120,7 +120,6 @@ def main(*,
          no_skip: bool = False,
          draft: bool = False,
          github_url: str,
-         default_branch: str,
          remote_name: str
          ) -> List[Optional[DiffMeta]]:
 
@@ -162,6 +161,9 @@ def main(*,
             repository(name: $name, owner: $owner) {
                 id
                 isFork
+                defaultBranchRef {
+                    name
+                }
             }
         }""",
         owner=repo_owner_nonopt,
@@ -178,6 +180,7 @@ def main(*,
             "error, please register your complaint on GitHub issues (or edit "
             "this line to delete the check above).".format(remote_name))
     repo_id = repo["id"]
+    default_branch = repo["defaultBranchRef"]["name"]
 
     sh.git("fetch", remote_name)
     base = GitCommitHash(sh.git("merge-base", f"{remote_name}/{default_branch}", "HEAD"))

--- a/ghstack/unlink.py
+++ b/ghstack/unlink.py
@@ -7,6 +7,8 @@ from typing import List, Optional, Set
 
 import ghstack.diff
 import ghstack.git
+import ghstack.github
+import ghstack.github_utils
 import ghstack.shell
 from ghstack.typing import GitCommitHash
 
@@ -15,9 +17,11 @@ RE_GHSTACK_SOURCE_ID = re.compile(r'^ghstack-source-id: (.+)\n?', re.MULTILINE)
 
 def main(*,
          commits: Optional[List[str]] = None,
+         github: ghstack.github.GitHubEndpoint,
          sh: Optional[ghstack.shell.Shell] = None,
+         repo_owner: Optional[str] = None,
+         repo_name: Optional[str] = None,
          github_url: str,
-         default_branch: str,
          remote_name: str) -> GitCommitHash:
     # If commits is empty, we unlink the entire stack
     #
@@ -28,6 +32,15 @@ def main(*,
     if sh is None:
         # Use CWD
         sh = ghstack.shell.Shell()
+
+    default_branch = ghstack.github_utils.get_github_repo_info(
+        github=github,
+        sh=sh,
+        repo_owner=repo_owner,
+        repo_name=repo_name,
+        github_url=github_url,
+        remote_name=remote_name,
+    )["default_branch"]
 
     # Parse the commits
     parsed_commits: Optional[Set[GitCommitHash]] = None

--- a/test_ghstack.py
+++ b/test_ghstack.py
@@ -110,7 +110,6 @@ class TestGh(expecttest.TestCase):
             short=short,
             no_skip=no_skip,
             github_url='github.com',
-            default_branch='master',
             remote_name='origin')
 
     def gh_land(self, pull_request: str) -> None:

--- a/test_ghstack.py
+++ b/test_ghstack.py
@@ -114,7 +114,6 @@ class TestGh(expecttest.TestCase):
 
     def gh_land(self, pull_request: str) -> None:
         return ghstack.land.main(
-            default_branch='master',
             remote_name='origin',
             pull_request=pull_request,
             github=self.github,
@@ -124,9 +123,11 @@ class TestGh(expecttest.TestCase):
 
     def gh_unlink(self) -> None:
         ghstack.unlink.main(
+            github=self.github,
             sh=self.sh,
+            repo_owner='pytorch',
+            repo_name='pytorch',
             github_url='github.com',
-            default_branch='master',
             remote_name='origin',
         )
 


### PR DESCRIPTION
Followup to [this discussion in #39](https://github.com/ezyang/ghstack/pull/39#discussion_r575613008). This PR does the following:

- [x] take the code from `ghstack.submit` to get the repo owner, name, ID, and fork status
- [x] move it into `ghstack.github_utils`
- [x] expand the GraphQL query slightly so now it also gets the default branch name
- [x] use that function to get the default branch in `ghstack.land` and `ghstack.unlink` too
- [x] remove `default_branch` from the config
- [x] add a test for using `submit` and `land` amidst changing a repo's default branch

This PR does not cache the default branch because I'm not sure how to properly do that if a repository's default branch can change over time.