### PR TITLE
Remove redundant CircleCI token redact

### DIFF
--- a/ghstack/__main__.py
+++ b/ghstack/__main__.py
@@ -141,8 +141,6 @@ def main() -> None:
             # TODO: Restructure this so that we just request
             # configurations "on-demand" rather than all upfront
             conf = ghstack.config.read_config(request_circle_token=True)
-            if conf.circle_token:
-                ghstack.logging.formatter.redact(conf.circle_token, '<CIRCLE_TOKEN>')
             circleci = ghstack.circleci_real.RealCircleCIEndpoint(
                 circle_token=conf.circle_token
             )


### PR DESCRIPTION
It looks like this was added to `ghstack.__main__` in bdba14b2f1d43db4a01d8e9d2452c501eb8950b3 and then later to `ghstack.config` in 60238391e2527ce05426f8519da73cd1a8508c3b, but while the latter commit removed the redundant `GITHUB_OAUTH` `redact` from `ghstack.__main__`, it didn't remove the corresponding `CIRCLE_TOKEN` redact; hence this PR.