### PR TITLE
Don't run double GitHub Actions on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,10 @@
 name: Test
 on:
-  - pull_request
-  - push
+  pull_request:
+  push:
+    branches:
+      - master
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Example: https://github.com/ezyang/ghstack/pull/46/commits/a9a2b09e6f715e64dd10f504baa2a9f764375d1b

A more elegant solution might be (instead of restricting the `push` trigger) to somehow modify the `pull_request` trigger to only run on PRs from forks, but this solution should also work fine.