### PR TITLE
Set encoding when reading github_schema.graphql

### DIFF
--- a/ghstack/github_fake.py
+++ b/ghstack/github_fake.py
@@ -238,7 +238,7 @@ class Root:
 
 
 with open(os.path.join(os.path.dirname(__file__),
-          'github_schema.graphql')) as f:
+          'github_schema.graphql'), encoding='utf-8') as f:
     GITHUB_SCHEMA = graphql.build_schema(f.read())
 
 


### PR DESCRIPTION
Currently, VS Code fails to [discover the tests](https://code.visualstudio.com/docs/python/testing#_enable-a-test-framework) (at least on macOS), because I think for some reason the locale is being set to ASCII, so `pytest` fails when reading the GitHub GraphQL schema:

https://github.com/ezyang/ghstack/blob/ecc3c401ab4b78e99ba7441897fe70c22b050ed5/ghstack/github_fake.py#L240-L242

This PR specifies the encoding explicitly, so now VS Code can successfully be used to run the tests (and debug specific ones, thanks to #53):

```json
{
  "python.testing.pytestArgs": [
    "."
  ],
  "python.testing.unittestEnabled": false,
  "python.testing.nosetestsEnabled": false,
  "python.testing.pytestEnabled": true
}
```