### PR TITLE
Autoclose config file after writing

### DIFF
--- a/ghstack/config.py
+++ b/ghstack/config.py
@@ -152,7 +152,8 @@ def read_config(*, request_circle_token: bool = False) -> Config:  # noqa: C901
         remote_name = 'origin'
 
     if write_back:
-        config.write(open(config_path, 'w'))
+        with open(config_path, 'w') as f:
+            config.write(f)
         logging.info("NB: configuration saved to {}".format(config_path))
 
     conf = Config(


### PR DESCRIPTION
I was getting this error previously:
```
ghstack/config.py:155: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/sestep/.ghstackrc' mode='w' encoding='UTF-8'>
  config.write(open(config_path, 'w'))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```