### PR TITLE
Add simple Chrome extension to delete merge button on ghstack PRs

### DIFF
--- a/chrome-extension/ghstack.js
+++ b/chrome-extension/ghstack.js
@@ -1,0 +1,11 @@
+"use strict";
+// Check if this is a ghstack PR
+for (const e of document.getElementsByClassName("base-ref")) {
+  if (e.innerText.match(/^gh\//)) {
+    // It is, delete the merge message (which contains the button)
+    for (const e of document.getElementsByClassName("merge-message")) {
+      e.remove();
+    }
+    break;
+  }
+}

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "ghstack extension",
+  "version": "1.0",
+  "manifest_version": 3,
+  "description": "GitHub UI enhancements for ghstack",
+  "content_scripts": [
+    {
+      "matches": ["https://github.com/*/*/pull/*"],
+      "run_at": "document_end",
+      "js": ["ghstack.js"]
+    }
+  ]
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60 Add simple Chrome extension to delete merge button on ghstack PRs**

It's wrong to click these buttons, so this PR makes it marginally
safer.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>