### PR TITLE
Unconditionally prune on fetches

### DIFF
--- a/ghstack/checkout.py
+++ b/ghstack/checkout.py
@@ -31,5 +31,5 @@ def main(pull_request: str,
 
     # TODO: Handle remotes correctly too (so this subsumes hub)
 
-    sh.git("fetch", remote_name)
+    sh.git("fetch", "--prune", remote_name)
     sh.git("checkout", remote_name + "/" + orig_ref)

--- a/ghstack/land.py
+++ b/ghstack/land.py
@@ -59,7 +59,7 @@ def main(pull_request: str,
         sh = ghstack.shell.Shell()
 
     # Get up-to-date
-    sh.git("fetch", remote_name)
+    sh.git("fetch", "--prune", remote_name)
     remote_orig_ref = remote_name + "/" + orig_ref
     base = GitCommitHash(sh.git("merge-base", f"{remote_name}/{default_branch}", remote_orig_ref))
 

--- a/ghstack/submit.py
+++ b/ghstack/submit.py
@@ -152,7 +152,7 @@ def main(*,
     repo_id = repo["id"]
     default_branch = repo["default_branch"]
 
-    sh.git("fetch", remote_name)
+    sh.git("fetch", "--prune", remote_name)
     base = GitCommitHash(sh.git("merge-base", f"{remote_name}/{default_branch}", "HEAD"))
 
     # compute the stack of commits to process (reverse chronological order),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #83
* __->__ #79

Pruning is not enabled by default for git because it is technically
destructive, but in practice noone really cares if we stomp all over
remote refs, especially because there are always tons and tons of
changes to remote refs in a ghstack workflow.

In return, we never have a situation where fetch fails because someone
did something naughty to a remote ref that git refuses to update, e.g.,
and error like:

```
error: cannot lock ref 'refs/remotes/origin/opinfo/one_hot': 'refs/remotes/origin/opinfo' exists; cannot create 'refs/remotes/origin/opinfo/one_hot'
 ! [new branch]            opinfo/one_hot          -> origin/opinfo/one_hot  (unable to update local ref)
 ```

Signed-off-by: Edward Z. Yang <ezyang@fb.com>