### PR TITLE
Add environment variable GHSTACK=1 on git executions

### DIFF
--- a/ghstack/shell.py
+++ b/ghstack/shell.py
@@ -247,6 +247,8 @@ class Shell(object):
             **kwargs: Any valid kwargs for sh()
         """
         env = kwargs.setdefault("env", {})
+        # For git hooks to detect execution inside ghstack
+        env.setdefault("GHSTACK", "1")
         # Some envvars to make things a little more script mode nice
         if self.testing:
             env.setdefault("EDITOR", ":")


### PR DESCRIPTION
This allows git hooks to detect execution inside `ghstack`. Our use case is that we have some pre-push checks that, when run inside `ghstack`, frequently fails due to the large number of pushes, so we want to tweak its behavior when these hooks are run inside `ghstack`.