### PR TITLE
Allow `typing-extensions` version `4.x`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -357,11 +357,11 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.7.4.3"
-description = "Backported and Experimental Type Hints for Python 3.5+"
+version = "4.1.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "urllib3"
@@ -404,7 +404,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "d20d1d3fd3e738c208c4ba47b6490586116b01f57acb06b6abfc3cb32b2f9b86"
+content-hash = "4a61c12b23013796a66e886cf7ab5b735cd58940574a052fd72827e36772439e"
 
 [metadata.files]
 aiohttp = [
@@ -653,9 +653,8 @@ typed-ast = [
     {file = "typed_ast-1.4.2.tar.gz", hash = "sha256:9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
-    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
-    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.3-py2.py3-none-any.whl", hash = "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dataclasses = { version = "^0.8", python = "<3.7" }
 importlib-metadata = "^3"
 python = "^3.6"
 requests = "^2"
-typing-extensions = "^3"
+typing-extensions = ">=3 <5"
 
 [tool.poetry.dev-dependencies]
 expecttest = "^0.1"


### PR DESCRIPTION
Currently, `[tool.poetry.dependencies]` is configured to only allow `typing-extensions` with major version `3`. `typing-extensions` was bumped to version `4`; I believe the only significant change is dropping Python 3.5 support, which is already unsupported by other dependencies. Allow version 4 to be used to avoid unnecessary package conflicts when installed in existing virtualenvs.