### PR TITLE
Fix https remote urls with trailing .git

### DIFF
--- a/ghstack/github_utils.py
+++ b/ghstack/github_utils.py
@@ -32,7 +32,7 @@ def get_github_repo_name_with_owner(
             owner = m.group(1)
             name = m.group(2)
             break
-        search = r'{github_url}/([^/]+)/(.+)'.format(
+        search = r'{github_url}/([^/]+)/(.+?)(?:\.git)?$'.format(
             github_url=github_url
         )
         m = re.search(search, remote_url)

--- a/test_ghstack.py
+++ b/test_ghstack.py
@@ -196,12 +196,30 @@ class TestGh(expecttest.TestCase):
             ),
             {"owner": "ezyang", "name": "ghstack"}
         )
+        self.sh.git("remote", "add", "https-with-dotgit", "https://github.com/ezyang/ghstack.git")
+        self.assertEqual(
+            ghstack.github_utils.get_github_repo_name_with_owner(
+                sh=self.sh,
+                github_url="github.com",
+                remote_name="https-with-dotgit"
+            ),
+            {"owner": "ezyang", "name": "ghstack"}
+        )
         self.sh.git("remote", "add", "https-with-dot", "https://github.com/ezyang/ghstack.dotted")
         self.assertEqual(
             ghstack.github_utils.get_github_repo_name_with_owner(
                 sh=self.sh,
                 github_url="github.com",
                 remote_name="https-with-dot"
+            ),
+            {"owner": "ezyang", "name": "ghstack.dotted"}
+        )
+        self.sh.git("remote", "add", "https-with-dot-with-dotgit", "https://github.com/ezyang/ghstack.dotted.git")
+        self.assertEqual(
+            ghstack.github_utils.get_github_repo_name_with_owner(
+                sh=self.sh,
+                github_url="github.com",
+                remote_name="https-with-dot-with-dotgit"
             ),
             {"owner": "ezyang", "name": "ghstack.dotted"}
         )


### PR DESCRIPTION
Summary:
I had cloned a repo and ended up with a remote uri like `https://github.com/evangrayk/foo.git`. `ghstack` was not parsing this correctly due to the trailing `.git`, due to #113.

The fix is to add a check to the regex for a trailing `.git`.


Test Plan:
Added test cases, tests pass