### PR TITLE
Allow author_name and author_email to be None

### DIFF
--- a/ghstack/diff.py
+++ b/ghstack/diff.py
@@ -115,5 +115,5 @@ class Diff:
 
     # The name and email of the author, used so we can preserve
     # authorship information when constructing a rebased commit
-    author_name: str
-    author_email: str
+    author_name: Optional[str]
+    author_email: Optional[str]

--- a/ghstack/submit.py
+++ b/ghstack/submit.py
@@ -645,16 +645,18 @@ Since we cannot proceed, ghstack will abort now.
                               number=number,
                               sourceid=commit.source_id,
                               github_url=self.github_url))
+        env = {}
+        if commit.author_name is not None:
+            env['GIT_AUTHOR_NAME'] = commit.author_name
+        if commit.author_email is not None:
+            env['GIT_AUTHOR_EMAIL'] = commit.author_email
 
         new_orig = GitCommitHash(self.sh.git(
             "commit-tree",
             *ghstack.gpg_sign.gpg_args_if_necessary(self.sh),
             "-p", self.base_orig,
             tree,
-            input=commit_msg, env={
-                'GIT_AUTHOR_NAME': commit.author_name,
-                'GIT_AUTHOR_EMAIL': commit.author_email
-            }))
+            input=commit_msg, env=env))
 
         self.stack_meta.append(DiffMeta(
             title=title,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #117
* #116

This is convenient for our internal integration.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>