### PR TITLE
Improve virtualenv developer experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@
 dist
 build
 .mypy_cache
+.python-version
+.venv/
 .vscode

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -ex
-isort . --check --diff
-black --check .
-flake8
-mypy --install-types --non-interactive .
+isort --check --diff ghstack
+black --check ghstack
+flake8 ghstack
+mypy --install-types --non-interactive -m ghstack
 pytest --verbose
 echo "OK"


### PR DESCRIPTION
- Adds pyenv version marker and common virtualenv name to .gitignore
- Updates `run_tests` script to specifically link ghstack dir/module

This improves the ability to build and test this project when using a
virtualenv, so that dependencies aren't installed to shared/global
site-packages.
