### PR TITLE
Switch to usort/ufmt for import sorting and formatting

### DIFF
--- a/ghstack/github_fake.py
+++ b/ghstack/github_fake.py
@@ -3,7 +3,7 @@
 import os.path
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, List, NewType, Optional, Sequence, cast
+from typing import Any, cast, Dict, List, NewType, Optional, Sequence
 
 import graphql
 from typing_extensions import TypedDict

--- a/ghstack/shell.py
+++ b/ghstack/shell.py
@@ -6,7 +6,7 @@ import os
 import shlex
 import subprocess
 import sys
-from typing import IO, Any, Dict, Optional, Sequence, Tuple, TypeVar, Union, overload
+from typing import Any, Dict, IO, Optional, overload, Sequence, Tuple, TypeVar, Union
 
 # Shell commands generally return str, but with exitcode=True
 # they return a bool, and if stdout is piped straight to sys.stdout

--- a/poetry.lock
+++ b/poetry.lock
@@ -213,18 +213,20 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "isort"
-version = "5.10.1"
-description = "A Python utility / library to sort Python imports."
+name = "libcst"
+version = "0.4.9"
+description = "A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7, 3.8, 3.9, and 3.10 programs."
 category = "dev"
 optional = false
-python-versions = ">=3.6.1,<4.0"
+python-versions = ">=3.7"
+
+[package.dependencies]
+pyyaml = ">=5.2"
+typing-extensions = ">=3.7.4.2"
+typing-inspect = ">=0.4.0"
 
 [package.extras]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
-requirements_deprecated_finder = ["pipreqs", "pip-api"]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
-plugins = ["setuptools"]
+dev = ["black (==22.10.0)", "coverage (>=4.5.4)", "fixit (==0.1.1)", "flake8 (>=3.7.8,<5)", "Sphinx (>=5.1.1)", "hypothesis (>=4.36.0)", "hypothesmith (>=0.0.4)", "jupyter (>=1.0.0)", "maturin (>=0.8.3,<0.14)", "nbsphinx (>=0.4.2)", "prompt-toolkit (>=2.0.9)", "setuptools-scm (>=6.0.1)", "sphinx-rtd-theme (>=0.4.3)", "ufmt (==2.0.1)", "usort (==1.0.5)", "setuptools-rust (>=1.5.2)", "slotscheck (>=0.7.1)", "jinja2 (==3.1.2)", "pyre-check (==0.9.9)"]
 
 [[package]]
 name = "mccabe"
@@ -233,6 +235,17 @@ description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "moreorless"
+version = "0.4.0"
+description = "Python diff wrapper"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+click = "*"
 
 [[package]]
 name = "multidict"
@@ -355,6 +368,14 @@ toml = "*"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+name = "pyyaml"
+version = "6.0"
+description = "YAML parser and emitter for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "requests"
 version = "2.28.1"
 description = "Python HTTP for Humans."
@@ -381,6 +402,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "stdlibs"
+version = "2022.10.9"
+description = "List of packages in the stdlib"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -397,12 +426,61 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "tomlkit"
+version = "0.11.6"
+description = "Style preserving TOML library"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "trailrunner"
+version = "1.2.1"
+description = "Run things on paths"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pathspec = ">=0.8.1"
+
+[[package]]
 name = "typing-extensions"
 version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "typing-inspect"
+version = "0.8.0"
+description = "Runtime inspection utilities for typing module."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+mypy-extensions = ">=0.3.0"
+typing-extensions = ">=3.7.4"
+
+[[package]]
+name = "ufmt"
+version = "2.0.1"
+description = "Safe, atomic formatting with black and µsort"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+black = ">=20.8b0"
+click = ">=8.0"
+libcst = ">=0.4.0"
+moreorless = ">=0.4.0"
+tomlkit = ">=0.7.2"
+trailrunner = ">=1.2.1"
+typing-extensions = ">=4.0"
+usort = ">=1.0"
 
 [[package]]
 name = "urllib3"
@@ -416,6 +494,23 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "urllib3-secure-extra", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "usort"
+version = "1.0.5"
+description = "A small, safe import sorter"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+attrs = ">=21.2.0"
+click = ">=7.0.0"
+LibCST = ">=0.3.7"
+moreorless = ">=0.3.0"
+stdlibs = ">=2021.4.1"
+toml = ">=0.10.0"
+trailrunner = ">=1.0"
 
 [[package]]
 name = "yarl"
@@ -432,7 +527,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "f367dc89e9ae393b41a0f6afe3790f9e3cdad1e57435ca82e0629d82ab6605d3"
+content-hash = "b9b4659e08d43c68de5a342bcc5fafccd6045c7a6b506fc8301012f825ac5bed"
 
 [metadata.files]
 aiohttp = []
@@ -453,8 +548,9 @@ graphql-core = []
 hypothesis = []
 idna = []
 iniconfig = []
-isort = []
+libcst = []
 mccabe = []
+moreorless = []
 multidict = []
 mypy = []
 mypy-extensions = []
@@ -466,10 +562,17 @@ py = []
 pycodestyle = []
 pyflakes = []
 pytest = []
+pyyaml = []
 requests = []
 sortedcontainers = []
+stdlibs = []
 toml = []
 tomli = []
+tomlkit = []
+trailrunner = []
 typing-extensions = []
+typing-inspect = []
+ufmt = []
 urllib3 = []
+usort = []
 yarl = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,11 @@ expecttest = "^0.1"
 flake8 = "^3"
 graphql-core = "^3"
 hypothesis = "^6"
-isort = "^5"
 mypy = "^1"
 pytest = "^6"
+usort = "^1"
+ufmt = "^2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.isort]
-profile = "black"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -ex
-isort --check --diff ghstack
-black --check ghstack
+export LIBCST_PARSER_TYPE=native
+ufmt check ghstack
 flake8 ghstack
 mypy --install-types --non-interactive -m ghstack
 pytest --verbose


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

ufmt presents a unified import sorting and formatting tool that builds
on usort[1] and black, and prevents any potential disagreement between
the two tools when running in tests/CI. usort furthermore uses a CST to
guarantee that modifications do not result in invalid syntax.

[1]: https://usort.readthedocs.io/en/stable/