### PR TITLE
Update supported versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-    runs-on: ubuntu-18.04
+        os: ["ubuntu-latest", "macos-latest"]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - 3.8
-          - 3.9
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Conveniently submit stacks of diffs to GitHub as separate pull requests.
 pip3 install ghstack
 ```
 
-Python 3.6 and greater only.
+Python 3.8 and greater only.
 
 ## How to setup
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #147
* #146
* #145
* __->__ #144

Peotry lockfile requires Python 3.8+, but readme still mentions 3.6.
Updates readme accordingly, and also adds CI to validate 3.10 and 3.11,
along with equivalent jobs for macOS.