### PR TITLE
Upgrade poetry version used in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Poetry
-        run: pipx install poetry==1.1.7
+        run: pipx install poetry==1.3.2
       - name: Install Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #147
* #146
* __->__ #145
* #144

This upgrades the version of poetry installed in CI from 1.1.7 to 1.3.2.
The new version supports the new lockfile format, and fixes a number of
runtime bugs that currently present on arm64/M1 Macs.

Updating the lockfile format happens in the next diff in the stack.