### PR TITLE
docs: do not run tests on Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Conveniently submit stacks of diffs to GitHub as separate pull requests.
 pip3 install ghstack
 ```
 
-Python 3.8 and greater only.
+Python 3.8 and greater only. For Python 3.12, dependencies might still need some fixing.
 
 ## How to setup
 


### PR DESCRIPTION
A while back, Python 3.12 became ga. We should therefore also test with this new Python version. As `ghstack` is OSS, the increase in the required capacity might not have the biggest impact.