### PR TITLE
chore: transform test script into Python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Install dependencies
         run: poetry install
       - name: Run tests
-        run: poetry run ./run_tests.sh
+        run: poetry run python run_tests.py

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ poetry run python test_ghstack.py
 ```
 That runs most of the tests; you can run all tests (including lints) like this:
 ```
-poetry run ./run_tests.sh
+poetry run python run_tests.py
 ```
 
 ### Publishing

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import subprocess
+import os
+
+# Set environment variable
+os.environ['LIBCST_PARSER_TYPE'] = 'native'
+
+
+def main():
+    try:
+        # ufmt check ghstack
+        subprocess.run(['ufmt', 'check', 'ghstack'], check=True)
+
+        # flake8 ghstack
+        subprocess.run(['flake8', 'ghstack'], check=True)
+
+        # mypy --install-types --non-interactive -m ghstack
+        subprocess.run(
+            ['mypy', '--install-types', '--non-interactive', '-m', 'ghstack'],
+            check=True)
+
+        # pytest --verbose
+        subprocess.run(['pytest', '--verbose'], check=True)
+
+        print("OK")
+
+    except subprocess.CalledProcessError as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-set -ex
-export LIBCST_PARSER_TYPE=native
-ufmt check ghstack
-flake8 ghstack
-mypy --install-types --non-interactive -m ghstack
-pytest --verbose
-echo "OK"


### PR DESCRIPTION
I am ashamed that I ignored the problem of running .sh scripts on Windows. :see_no_evil: 

Instead of maintaining a separate Bash and Powershell script, I transformed the script into a simple Python script. After a rebase, #167 should also succeed.

Currently, I cannot really test on a Windows machine. However, in Powershell and standard Ubuntu containers, the execution works smoothly.