### PR TITLE
ci: install Poetry version `1.7.1`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Poetry
-        run: pipx install poetry==1.3.2
+        run: pipx install poetry==1.7.1
       - name: Install Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
I first tried to rabbit hole into specifying many sub-dependencies. However, this results in very old dependencies and a complicated list of dependencies. As it eventually turned out, I just needed to update the Poetry version which gets installed during our CI process.

Testing the project with a recent version of Poetry fixes the experienced dependency issues and closes #172. 