### PR TITLE
Undo Patch abstraction

### DIFF
--- a/ghstack/git.py
+++ b/ghstack/git.py
@@ -66,20 +66,6 @@ def split_header(s: str) -> List[CommitHeader]:
     return list(map(CommitHeader, s.split("\0")[:-1]))
 
 
-class GitPatch(ghstack.diff.Patch):
-    h: CommitHeader
-
-    def __init__(self, h: CommitHeader):
-        self.h = h
-
-    def apply(self, sh: ghstack.shell.Shell, base_tree: GitTreeHash) -> GitTreeHash:
-        expected_tree = sh.git("rev-parse", self.h.commit_id() + "~^{tree}")
-        assert expected_tree == base_tree, "expected_tree = {}, base_tree = {}".format(
-            expected_tree, base_tree
-        )
-        return self.h.tree()
-
-
 def parse_header(s: str, github_url: str) -> List[ghstack.diff.Diff]:
     def convert(h: CommitHeader) -> ghstack.diff.Diff:
         parents = h.parents()
@@ -98,7 +84,7 @@ def parse_header(s: str, github_url: str) -> List[ghstack.diff.Diff]:
             pull_request_resolved=ghstack.diff.PullRequestResolved.search(
                 h.raw_header, github_url
             ),
-            patch=GitPatch(h),
+            tree=h.tree(),
             author_name=h.author_name(),
             author_email=h.author_email(),
         )

--- a/ghstack/submit.py
+++ b/ghstack/submit.py
@@ -686,7 +686,7 @@ Since we cannot proceed, ghstack will abort now.
         ghnum = GhNumber(str(max_ref_num + 1))
 
         # Create the incremental pull request diff
-        tree = commit.patch.apply(self.sh, self.base_tree)
+        tree = commit.tree
 
         # Actually, if there's no change in the tree, stop processing
         if tree == self.base_tree:
@@ -954,7 +954,7 @@ Since we cannot proceed, ghstack will abort now.
         # Blast our current tree as the newest commit, merging
         # against the previous pull entry, and the newest base.
 
-        tree = commit.patch.apply(self.sh, self.base_tree)
+        tree = commit.tree
 
         # Nothing to do, just ignore the diff
         if tree == self.base_tree:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #200
* #199
* __->__ #198

I am trying to implement incremental updates and the patch abstraction
is the wrong way to go about doing it, because you in general don't have
a base tree to apply the patch on; you need the full git tree object
somehow.  This will break ghexport when we take these updates but it's
going to be complicated to handle anyway, deal with it when we get
there.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>