### PR TITLE
ci: test with Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Conveniently submit stacks of diffs to GitHub as separate pull requests.
 pip3 install ghstack
 ```
 
-Python 3.8.1 and greater only. For Python 3.12, dependencies might still need some fixing.
+ghstack is tested with 
+[several different Python versions](https://github.com/ezyang/ghstack/blob/master/.github/workflows/test.yml#L13). 
+It requires at least Python 3.8.1.
 
 ## How to setup
 


### PR DESCRIPTION
With our recent version upgrades, tests also succeed with Python 3.12. By adding testing with Python 3.12, we can ensure that ghstack works with all current Python versions.