### PR TITLE
Fix github enterprise api url

### DIFF
--- a/ghstack/config.py
+++ b/ghstack/config.py
@@ -140,8 +140,13 @@ def read_config(
     if config.has_option("ghstack", "github_username"):
         github_username = config.get("ghstack", "github_username")
     if github_username is None and github_oauth is not None:
+        request_url: str
+        if "{github_url}" == "github.com":
+            request_url = f"https://api.{github_url}/user"
+        else:
+            request_url = f"https://{github_url}/api/v3/user"
         res = requests.get(
-            f"https://api.{github_url}/user",
+            request_url,
             headers={
                 "Accept": "application/vnd.github+json",
                 "Authorization": f"Bearer {github_oauth}",

--- a/ghstack/github_real.py
+++ b/ghstack/github_real.py
@@ -17,11 +17,19 @@ class RealGitHubEndpoint(ghstack.github.GitHubEndpoint):
     """
 
     # The URL of the GraphQL endpoint to connect to
-    graphql_endpoint: str = "https://api.{github_url}/graphql"
+    graphql_endpoint: str
+    if "{github_url}" == "github.com":
+        graphql_endpoint = "https://api.{github_url}/graphql"
+    else:
+        graphql_endpoint = "https://{github_url}/api/graphql"
 
     # The base URL of the REST endpoint to connect to (all REST requests
     # will be subpaths of this URL)
-    rest_endpoint: str = "https://api.{github_url}"
+    rest_endpoint: str
+    if "{github_url}" == "github.com":
+        rest_endpoint = "https://api.{github_url}"
+    else:
+        rest_endpoint = "https://{github_url}/api/v3"
 
     # The base URL of regular WWW website, in case we need to manually
     # interact with the real website


### PR DESCRIPTION
references:
![GraphQL API](https://github.com/ezyang/ghstack/assets/7322527/672e93ed-bfc5-48e7-a3d4-f8c5cb738db1)
- GraphQL API: https://docs.github.com/en/enterprise-server@3.12/graphql/guides/forming-calls-with-graphql#the-graphql-endpoint

![REST API](https://github.com/ezyang/ghstack/assets/7322527/ac3f7e65-87b6-4784-ada2-f4ee36f36ca8)
- REST API: https://docs.github.com/en/enterprise-server@3.12/rest/meta/meta?apiVersion=2022-11-28#github-api-root

