### PR TITLE
Add a parent commit pointing to orig base to help CI scripts out

### DIFF
--- a/test/land/default_branch_change.py.test
+++ b/test/land/default_branch_change.py.test
@@ -25,14 +25,16 @@ assert_github_state(
 
             This is commit A
 
-            * 36498d0 Initial 1
+            * 36fcfdf Initial 1
 
         Repository state:
 
-            * 36498d0 (gh/ezyang/1/head)
+            * 36fcfdf (gh/ezyang/1/head)
             |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * 5a32949 (gh/ezyang/1/base)
+            |    Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
 )
 
@@ -71,7 +73,7 @@ assert_github_state(
 
             This is commit A
 
-            * 36498d0 Initial 1
+            * 36fcfdf Initial 1
 
         [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
 
@@ -80,18 +82,22 @@ assert_github_state(
 
             This is commit B
 
-            * f30ebce Initial 2
+            * cfc0530 Initial 2
 
         Repository state:
 
-            * f30ebce (gh/ezyang/2/head)
+            * cfc0530 (gh/ezyang/2/head)
             |    Initial 2
-            * 94673ed (gh/ezyang/2/base)
-                 Initial 2 (base update)
-            * 36498d0 (gh/ezyang/1/head)
-            |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * bf457db (gh/ezyang/2/base)
+            |    Initial 2 (base update)
+            * 8b023bd (main, gh/ezyang/1/orig)
+            |    Commit A
+            | * 36fcfdf (gh/ezyang/1/head)
+            | |    Initial 1
+            | * 5a32949 (gh/ezyang/1/base)
+            |/     Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
 )
 

--- a/test/land/invalid_resubmit.py.test
+++ b/test/land/invalid_resubmit.py.test
@@ -44,14 +44,18 @@ else:
 
             This is commit A
 
-            * 5f66713 New PR
+            * edc8acf New PR
 
         Repository state:
 
-            * 5f66713 (gh/ezyang/1/head)
+            * edc8acf (gh/ezyang/1/head)
             |    New PR
-            * dd7d794 (gh/ezyang/1/base)
-                 New PR (base update)
+            * b38da4f (gh/ezyang/1/base)
+            |    New PR (base update)
+            * 8b023bd (HEAD -> master)
+            |    Commit A
+            * dc8bfe4
+                 Initial commit
         """
     )
 

--- a/test/land/update_after_land.py.test
+++ b/test/land/update_after_land.py.test
@@ -55,19 +55,25 @@ else:
 
             This is commit B
 
-            * ea56242 Run 3
-            * a3419f5 Initial 1
+            * 885020e Run 3
+            * d96fc53 Initial 1
 
         Repository state:
 
-            *   ea56242 (gh/ezyang/2/head)
+            *   885020e (gh/ezyang/2/head)
             |\\     Run 3
-            | * c7cbff7 (gh/ezyang/2/base)
-            | |    Run 3 (base update)
-            * | a3419f5
-            |/     Initial 1
-            * c66825d
-                 Initial 1 (base update)
+            | *   1396fc7 (gh/ezyang/2/base)
+            | |\\     Run 3 (base update)
+            | | * 7f0288c
+            | | |    Commit U
+            * | | d96fc53
+            |/ /     Initial 1
+            * | 20df153
+            | |    Initial 1 (base update)
+            * | c5f6953
+            |/     Commit A
+            * dc8bfe4
+                 Initial commit
         """
     )
 

--- a/test/submit/amend.py.test
+++ b/test/submit/amend.py.test
@@ -38,16 +38,18 @@ else:
 
             This is commit A
 
-            * 5d7b4a1 Update A
-            * 36498d0 Initial 1
+            * f004e08 Update A
+            * 36fcfdf Initial 1
 
         Repository state:
 
-            * 5d7b4a1 (gh/ezyang/1/head)
+            * f004e08 (gh/ezyang/1/head)
             |    Update A
-            * 36498d0
+            * 36fcfdf
             |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * 5a32949 (gh/ezyang/1/base)
+            |    Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """,
     )

--- a/test/submit/amend_all.py.test
+++ b/test/submit/amend_all.py.test
@@ -56,8 +56,8 @@ else:
 
             This is commit A
 
-            * 2beb1f1 Update A
-            * 36498d0 Initial 1
+            * 3bc91e8 Update A
+            * 36fcfdf Initial 1
 
         [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
 
@@ -67,24 +67,28 @@ else:
 
             This is commit B
 
-            * 4430ba6 Update A
-            * f30ebce Initial 2
+            * 3fb0bed Update A
+            * cfc0530 Initial 2
 
         Repository state:
 
-            * 2beb1f1 (gh/ezyang/1/head)
+            * 3bc91e8 (gh/ezyang/1/head)
             |    Update A
-            * 36498d0
+            * 36fcfdf
             |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
-            *   4430ba6 (gh/ezyang/2/head)
-            |\\     Update A
-            | * d315f95 (gh/ezyang/2/base)
-            | |    Update A (base update)
-            * | f30ebce
-            |/     Initial 2
-            * 94673ed
-                 Initial 2 (base update)
+            * 5a32949 (gh/ezyang/1/base)
+            |    Initial 1 (base update)
+            | *   3fb0bed (gh/ezyang/2/head)
+            | |\\     Update A
+            | | * edd4564 (gh/ezyang/2/base)
+            | | |    Update A (base update)
+            | * | cfc0530
+            | |/     Initial 2
+            | * bf457db
+            | |    Initial 2 (base update)
+            | * 8b023bd
+            |/     Commit A
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )

--- a/test/submit/amend_bottom.py.test
+++ b/test/submit/amend_bottom.py.test
@@ -56,8 +56,8 @@ else:
 
             This is commit A
 
-            * 23930b1 Update A
-            * 36498d0 Initial 1
+            * 414cdf2 Update A
+            * 36fcfdf Initial 1
 
         [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
 
@@ -67,24 +67,28 @@ else:
 
             This is commit B
 
-            * 976c018 Update B
-            * f30ebce Initial 2
+            * c11f047 Update B
+            * cfc0530 Initial 2
 
         Repository state:
 
-            *   976c018 (gh/ezyang/2/head)
+            *   c11f047 (gh/ezyang/2/head)
             |\\     Update B
-            | * e3a6e9d (gh/ezyang/2/base)
+            | * 7c6b228 (gh/ezyang/2/base)
             | |    Update B (base update)
-            * | f30ebce
+            * | cfc0530
             |/     Initial 2
-            * 94673ed
-                 Initial 2 (base update)
-            * 23930b1 (gh/ezyang/1/head)
-            |    Update A
-            * 36498d0
-            |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * bf457db
+            |    Initial 2 (base update)
+            * 8b023bd
+            |    Commit A
+            | * 414cdf2 (gh/ezyang/1/head)
+            | |    Update A
+            | * 36fcfdf
+            | |    Initial 1
+            | * 5a32949 (gh/ezyang/1/base)
+            |/     Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """,
     )

--- a/test/submit/amend_message_only.py.test
+++ b/test/submit/amend_message_only.py.test
@@ -36,14 +36,16 @@ else:
 
             This is commit AAA
 
-            * 6f7501b Initial 1
+            * 1081a5b Initial 1
 
         Repository state:
 
-            * 6f7501b (gh/ezyang/1/head)
+            * 1081a5b (gh/ezyang/1/head)
             |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * 5a32949 (gh/ezyang/1/base)
+            |    Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """,
     )
 

--- a/test/submit/amend_top.py.test
+++ b/test/submit/amend_top.py.test
@@ -50,7 +50,7 @@ else:
 
             This is commit A
 
-            * 36498d0 Initial 1
+            * 36fcfdf Initial 1
 
         [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
 
@@ -60,20 +60,24 @@ else:
 
             This is commit B
 
-            * 339d734 Update A
-            * f30ebce Initial 2
+            * 9a4a9ae Update A
+            * cfc0530 Initial 2
 
         Repository state:
 
-            * 339d734 (gh/ezyang/2/head)
+            * 9a4a9ae (gh/ezyang/2/head)
             |    Update A
-            * f30ebce
+            * cfc0530
             |    Initial 2
-            * 94673ed (gh/ezyang/2/base)
-                 Initial 2 (base update)
-            * 36498d0 (gh/ezyang/1/head)
-            |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * bf457db (gh/ezyang/2/base)
+            |    Initial 2 (base update)
+            * 8b023bd
+            |    Commit A
+            | * 36fcfdf (gh/ezyang/1/head)
+            | |    Initial 1
+            | * 5a32949 (gh/ezyang/1/base)
+            |/     Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """,
     )

--- a/test/submit/bullet_divider.py.test
+++ b/test/submit/bullet_divider.py.test
@@ -45,14 +45,16 @@ else:
             * It starts with a fabulous
             * Bullet list
 
-            * 6ee2f33 Initial
+            * 7e90855 Initial
 
         Repository state:
 
-            * 6ee2f33 (gh/ezyang/1/head)
+            * 7e90855 (gh/ezyang/1/head)
             |    Initial
-            * 4e54cdd (gh/ezyang/1/base)
-                 Initial (base update)
+            * 11e6d4d (gh/ezyang/1/base)
+            |    Initial (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )
 

--- a/test/submit/cherry_pick.py.test
+++ b/test/submit/cherry_pick.py.test
@@ -57,7 +57,7 @@ else:
 
             This is commit A
 
-            * ab3db60 Initial 2
+            * 12d35d5 Initial 2
 
         [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
 
@@ -66,22 +66,26 @@ else:
 
             This is commit B
 
-            * 40beaad Cherry pick
-            * f30ebce Initial 2
+            * 80be1e3 Cherry pick
+            * ca4399f Initial 2
 
         Repository state:
 
-            *   40beaad (gh/ezyang/2/head)
+            *   80be1e3 (gh/ezyang/2/head)
             |\\     Cherry pick
-            | * 3bf3b56 (gh/ezyang/2/base)
-            | |    Cherry pick (base update)
-            * | f30ebce
-            |/     Initial 2
-            * 94673ed
-                 Initial 2 (base update)
-            * ab3db60 (gh/ezyang/1/head)
-            |    Initial 2
-            * e957508 (gh/ezyang/1/base)
-                 Initial 2 (base update)
+            | *   8f5c855 (gh/ezyang/2/base)
+            | |\\     Cherry pick (base update)
+            | | * 7ceeaa9 (HEAD -> master)
+            | | |    Commit M
+            * | | ca4399f
+            |/ /     Initial 2
+            * / c05297f
+            |/     Initial 2 (base update)
+            | * 12d35d5 (gh/ezyang/1/head)
+            | |    Initial 2
+            | * f081adc (gh/ezyang/1/base)
+            |/     Initial 2 (base update)
+            * dc8bfe4
+                 Initial commit
         """
     )

--- a/test/submit/commit_amended_to_empty.py.test
+++ b/test/submit/commit_amended_to_empty.py.test
@@ -24,13 +24,15 @@ if not is_direct():
 
             This is my first commit
 
-            * cfa2c39 Initial
+            * 20f4f38 Initial
 
         Repository state:
 
-            * cfa2c39 (gh/ezyang/1/head)
+            * 20f4f38 (gh/ezyang/1/head)
             |    Initial
-            * bd0a7b9 (gh/ezyang/1/base)
-                 Initial (base update)
+            * ce88e73 (gh/ezyang/1/base)
+            |    Initial (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """,
     )

--- a/test/submit/do_not_revert_local_commit_msg_on_skip.py.test
+++ b/test/submit/do_not_revert_local_commit_msg_on_skip.py.test
@@ -58,14 +58,16 @@ else:
 
             This is commit TO_REPLACE
 
-            * bfe45a3 Initial
+            * 5bb1f7c Initial
 
         Repository state:
 
-            * bfe45a3 (gh/ezyang/1/head)
+            * 5bb1f7c (gh/ezyang/1/head)
             |    Initial
-            * 4e54cdd (gh/ezyang/1/base)
-                 Initial (base update)
+            * 11e6d4d (gh/ezyang/1/base)
+            |    Initial (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )
 

--- a/test/submit/empty_commit.py.test
+++ b/test/submit/empty_commit.py.test
@@ -17,13 +17,17 @@ else:
 
             This is commit B
 
-            * 672cd30 Initial
+            * 50f7665 Initial
 
         Repository state:
 
-            * 672cd30 (gh/ezyang/1/head)
+            * 50f7665 (gh/ezyang/1/head)
             |    Initial
-            * 4e54cdd (gh/ezyang/1/base)
-                 Initial (base update)
+            * 23298b8 (gh/ezyang/1/base)
+            |    Initial (base update)
+            * 31a6b65
+            |    Commit 1
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )

--- a/test/submit/multi.py.test
+++ b/test/submit/multi.py.test
@@ -40,7 +40,7 @@ else:
 
             This is commit A
 
-            * 777af59 Initial 1 and 2
+            * 53948da Initial 1 and 2
 
         [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
 
@@ -50,17 +50,21 @@ else:
 
             This is commit B
 
-            * 3c3426d Initial 1 and 2
+            * 9f28612 Initial 1 and 2
 
         Repository state:
 
-            * 777af59 (gh/ezyang/1/head)
+            * 53948da (gh/ezyang/1/head)
             |    Initial 1 and 2
-            * 873273a (gh/ezyang/1/base)
-                 Initial 1 and 2 (base update)
-            * 3c3426d (gh/ezyang/2/head)
-            |    Initial 1 and 2
-            * 9f0da86 (gh/ezyang/2/base)
-                 Initial 1 and 2 (base update)
+            * cc79b9e (gh/ezyang/1/base)
+            |    Initial 1 and 2 (base update)
+            | * 9f28612 (gh/ezyang/2/head)
+            | |    Initial 1 and 2
+            | * febf650 (gh/ezyang/2/base)
+            | |    Initial 1 and 2 (base update)
+            | * c5f6953
+            |/     Commit A
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )

--- a/test/submit/no_clobber.py.test
+++ b/test/submit/no_clobber.py.test
@@ -50,14 +50,16 @@ else:
 
             Directly updated message body
 
-            * 20ec3e0 Initial 1
+            * 54d43aa Initial 1
 
         Repository state:
 
-            * 20ec3e0 (gh/ezyang/1/head)
+            * 54d43aa (gh/ezyang/1/head)
             |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * 5a32949 (gh/ezyang/1/base)
+            |    Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )
 
@@ -100,16 +102,18 @@ else:
 
             Directly updated message body
 
-            * 4300988 Update 1
-            * 20ec3e0 Initial 1
+            * 66af150 Update 1
+            * 54d43aa Initial 1
 
         Repository state:
 
-            * 4300988 (gh/ezyang/1/head)
+            * 66af150 (gh/ezyang/1/head)
             |    Update 1
-            * 20ec3e0
+            * 54d43aa
             |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * 5a32949 (gh/ezyang/1/base)
+            |    Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )

--- a/test/submit/no_clobber_carriage_returns.py.test
+++ b/test/submit/no_clobber_carriage_returns.py.test
@@ -38,14 +38,16 @@ else:
 
             Original message
 
-            * 20ec3e0 Initial 1
+            * 54d43aa Initial 1
 
         Repository state:
 
-            * 20ec3e0 (gh/ezyang/1/head)
+            * 54d43aa (gh/ezyang/1/head)
             |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * 5a32949 (gh/ezyang/1/base)
+            |    Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )
 
@@ -107,7 +109,7 @@ else:
 
             Directly updated message body
 
-            * 20ec3e0 Initial 1
+            * 54d43aa Initial 1
 
         [O] #501 Commit 2 (gh/ezyang/2/head -> gh/ezyang/2/base)
 
@@ -117,17 +119,21 @@ else:
 
 
 
-            * 43303fd Initial 2
+            * 95915be Initial 2
 
         Repository state:
 
-            * 43303fd (gh/ezyang/2/head)
+            * 95915be (gh/ezyang/2/head)
             |    Initial 2
-            * 7315319 (gh/ezyang/2/base)
-                 Initial 2 (base update)
-            * 20ec3e0 (gh/ezyang/1/head)
-            |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * 30049f9 (gh/ezyang/2/base)
+            |    Initial 2 (base update)
+            * 6f81292
+            |    Commit 1
+            | * 54d43aa (gh/ezyang/1/head)
+            | |    Initial 1
+            | * 5a32949 (gh/ezyang/1/base)
+            |/     Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )

--- a/test/submit/non_standard_base.py.test
+++ b/test/submit/non_standard_base.py.test
@@ -49,14 +49,18 @@ else:
 
             This is commit A
 
-            * dedc4f1 Initial 1
+            * 19687ac Initial 1
 
         Repository state:
 
-            * dedc4f1 (gh/ezyang/1/head)
+            * 19687ac (gh/ezyang/1/head)
             |    Initial 1
-            * ab82953 (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * 7687c36 (gh/ezyang/1/base)
+            |    Initial 1 (base update)
+            * 9ac8806 (release)
+            |    Commit R
+            * dc8bfe4
+                 Initial commit
         """
     )
 

--- a/test/submit/rebase.py.test
+++ b/test/submit/rebase.py.test
@@ -60,8 +60,8 @@ else:
 
             This is commit A
 
-            * 0ed6144 Rebase
-            * 36498d0 Initial 1
+            * cdf0f81 Rebase
+            * 36fcfdf Initial 1
 
         [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
 
@@ -71,26 +71,32 @@ else:
 
             This is commit B
 
-            * e92f0ac Rebase
-            * f30ebce Initial 2
+            * d981090 Rebase
+            * ca4399f Initial 2
 
         Repository state:
 
-            *   0ed6144 (gh/ezyang/1/head)
+            *   cdf0f81 (gh/ezyang/1/head)
             |\\     Rebase
-            | * a094338 (gh/ezyang/1/base)
-            | |    Rebase (base update)
-            * | 36498d0
-            |/     Initial 1
-            * 3e4048c
-                 Initial 1 (base update)
-            *   e92f0ac (gh/ezyang/2/head)
-            |\\     Rebase
-            | * c1ad9fe (gh/ezyang/2/base)
-            | |    Rebase (base update)
-            * | f30ebce
-            |/     Initial 2
-            * 94673ed
-                 Initial 2 (base update)
+            | *   107d5ce (gh/ezyang/1/base)
+            | |\\     Rebase (base update)
+            * | | 36fcfdf
+            |/ /     Initial 1
+            * | 5a32949
+            | |    Initial 1 (base update)
+            | | *   d981090 (gh/ezyang/2/head)
+            | | |\\     Rebase
+            | | | *   d80b302 (gh/ezyang/2/base)
+            | | | |\\     Rebase (base update)
+            | | |_|/
+            | |/| |
+            | * | | 7ceeaa9 (HEAD -> master)
+            |/ / /     Commit M
+            | * / ca4399f
+            | |/     Initial 2
+            | * c05297f
+            |/     Initial 2 (base update)
+            * dc8bfe4
+                 Initial commit
         """
     )

--- a/test/submit/reject_head_stack.py.test
+++ b/test/submit/reject_head_stack.py.test
@@ -34,7 +34,18 @@ else:
     assert_expected_raises_inline(
         RuntimeError,
         lambda: gh_submit("Initial 2"),
-        """The commit 3e4048c2f33782ae288f36f5fa10281ce0bdb6ec has 0 parents, which makes my head explode.  `git rebase -i` your diffs into a stack, then try again.""",
+        """\
+This commit is poisoned: it is from a head or base branch--ghstack
+cannot validly submit it.  The most common situation for this to
+happen is if you checked out the head branch of a pull request that was
+previously submitted with ghstack (e.g., by using hub checkout).
+Making modifications on the head branch is not supported; instead,
+you should fetch the original commits in question by running:
+
+ghstack checkout $PR_URL
+
+Since we cannot proceed, ghstack will abort now.
+""",
     )
 
 # ------------------------------------------------------------------------- #

--- a/test/submit/remove_bottom_commit.py.test
+++ b/test/submit/remove_bottom_commit.py.test
@@ -54,7 +54,7 @@ else:
 
             This is commit A
 
-            * ab3db60 Initial 2
+            * 12d35d5 Initial 2
 
         [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
 
@@ -63,23 +63,25 @@ else:
 
             This is commit B
 
-            * 4c3b577 Cherry pick
-            * f30ebce Initial 2
+            * 2c3ea13 Cherry pick
+            * ca4399f Initial 2
 
         Repository state:
 
-            *   4c3b577 (gh/ezyang/2/head)
+            *   2c3ea13 (gh/ezyang/2/head)
             |\\     Cherry pick
-            | * f368920 (gh/ezyang/2/base)
+            | * a8c0a6e (gh/ezyang/2/base)
             | |    Cherry pick (base update)
-            * | f30ebce
+            * | ca4399f
             |/     Initial 2
-            * 94673ed
-                 Initial 2 (base update)
-            * ab3db60 (gh/ezyang/1/head)
-            |    Initial 2
-            * e957508 (gh/ezyang/1/base)
-                 Initial 2 (base update)
+            * c05297f
+            |    Initial 2 (base update)
+            | * 12d35d5 (gh/ezyang/1/head)
+            | |    Initial 2
+            | * f081adc (gh/ezyang/1/base)
+            |/     Initial 2 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )
 

--- a/test/submit/reorder.py.test
+++ b/test/submit/reorder.py.test
@@ -53,8 +53,8 @@ else:
 
             This is commit A
 
-            * 2c54930 Reorder
-            * ce752f6 Initial
+            * 56b24a9 Reorder
+            * 4afba7b Initial
 
         [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
 
@@ -64,26 +64,30 @@ else:
 
             This is commit B
 
-            * d85a07e Reorder
-            * 20d8f25 Initial
+            * a9a3f2b Reorder
+            * f420265 Initial
 
         Repository state:
 
-            *   2c54930 (gh/ezyang/1/head)
+            *   56b24a9 (gh/ezyang/1/head)
             |\\     Reorder
-            | * df39342 (gh/ezyang/1/base)
+            | * d4668d1 (gh/ezyang/1/base)
             | |    Reorder (base update)
-            * | ce752f6
+            * | 4afba7b
             |/     Initial
-            * 5a1c625
-                 Initial (base update)
-            *   d85a07e (gh/ezyang/2/head)
-            |\\     Reorder
-            | * 47b1e1f (gh/ezyang/2/base)
-            | |    Reorder (base update)
-            * | 20d8f25
-            |/     Initial
-            * 770af83
-                 Initial (base update)
+            * 13c3cb3
+            |    Initial (base update)
+            | *   a9a3f2b (gh/ezyang/2/head)
+            | |\\     Reorder
+            | | * 6d3e372 (gh/ezyang/2/base)
+            | | |    Reorder (base update)
+            | * | f420265
+            | |/     Initial
+            | * 8e45110
+            | |    Initial (base update)
+            | * c5f6953
+            |/     Commit A
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )

--- a/test/submit/simple.py.test
+++ b/test/submit/simple.py.test
@@ -46,7 +46,7 @@ else:
 
             This is commit A
 
-            * 36498d0 Initial 1
+            * 36fcfdf Initial 1
 
         [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
 
@@ -56,18 +56,22 @@ else:
 
             This is commit B
 
-            * f30ebce Initial 2
+            * cfc0530 Initial 2
 
         Repository state:
 
-            * f30ebce (gh/ezyang/2/head)
+            * cfc0530 (gh/ezyang/2/head)
             |    Initial 2
-            * 94673ed (gh/ezyang/2/base)
-                 Initial 2 (base update)
-            * 36498d0 (gh/ezyang/1/head)
-            |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * bf457db (gh/ezyang/2/base)
+            |    Initial 2 (base update)
+            * 8b023bd
+            |    Commit A
+            | * 36fcfdf (gh/ezyang/1/head)
+            | |    Initial 1
+            | * 5a32949 (gh/ezyang/1/base)
+            |/     Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """,
     )
 

--- a/test/submit/unrelated_malformed_gh_branch_ok.py.test
+++ b/test/submit/unrelated_malformed_gh_branch_ok.py.test
@@ -54,7 +54,7 @@ else:
 
             This is commit A
 
-            * 36498d0 Initial 1
+            * 36fcfdf Initial 1
 
         [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
 
@@ -64,18 +64,20 @@ else:
 
             This is commit B
 
-            * f30ebce Initial 2
+            * cfc0530 Initial 2
 
         Repository state:
 
-            * f30ebce (gh/ezyang/2/head)
+            * cfc0530 (gh/ezyang/2/head)
             |    Initial 2
-            * 94673ed (gh/ezyang/2/base)
-                 Initial 2 (base update)
-            * 36498d0 (gh/ezyang/1/head)
-            |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * bf457db (gh/ezyang/2/base)
+            |    Initial 2 (base update)
+            * 8b023bd
+            |    Commit A
+            | * 36fcfdf (gh/ezyang/1/head)
+            | |    Initial 1
+            | * 5a32949 (gh/ezyang/1/base)
+            |/     Initial 1 (base update)
             * dc8bfe4 (HEAD -> master, gh/ezyang/non_int/head, gh/ezyang/malform)
                  Initial commit
         """,

--- a/test/submit/update_fields.py.test
+++ b/test/submit/update_fields.py.test
@@ -40,14 +40,16 @@ else:
 
             Directly updated message body
 
-            * 20ec3e0 Initial 1
+            * 54d43aa Initial 1
 
         Repository state:
 
-            * 20ec3e0 (gh/ezyang/1/head)
+            * 54d43aa (gh/ezyang/1/head)
             |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * 5a32949 (gh/ezyang/1/base)
+            |    Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )
 
@@ -80,14 +82,16 @@ else:
 
             Original message
 
-            * 20ec3e0 Initial 1
+            * 54d43aa Initial 1
 
         Repository state:
 
-            * 20ec3e0 (gh/ezyang/1/head)
+            * 54d43aa (gh/ezyang/1/head)
             |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * 5a32949 (gh/ezyang/1/base)
+            |    Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )
 

--- a/test/submit/update_fields_preserve_differential_revision.py.test
+++ b/test/submit/update_fields_preserve_differential_revision.py.test
@@ -50,14 +50,16 @@ else:
             Differential Revision: [D14778507](https://our.internmc.facebook.com/intern/diff/D14778507)
 
 
-            * 36498d0 Initial 1
+            * 36fcfdf Initial 1
 
         Repository state:
 
-            * 36498d0 (gh/ezyang/1/head)
+            * 36fcfdf (gh/ezyang/1/head)
             |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * 5a32949 (gh/ezyang/1/base)
+            |    Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )
 
@@ -94,14 +96,16 @@ else:
 
             Differential Revision: [D14778507](https://our.internmc.facebook.com/intern/diff/D14778507)
 
-            * 36498d0 Initial 1
+            * 36fcfdf Initial 1
 
         Repository state:
 
-            * 36498d0 (gh/ezyang/1/head)
+            * 36fcfdf (gh/ezyang/1/head)
             |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * 5a32949 (gh/ezyang/1/base)
+            |    Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )
 

--- a/test/submit/update_fields_preserves_commit_message.py.test
+++ b/test/submit/update_fields_preserves_commit_message.py.test
@@ -37,14 +37,16 @@ else:
 
             This is commit A
 
-            * 36498d0 Initial 1
+            * 36fcfdf Initial 1
 
         Repository state:
 
-            * 36498d0 (gh/ezyang/1/head)
+            * 36fcfdf (gh/ezyang/1/head)
             |    Initial 1
-            * 3e4048c (gh/ezyang/1/base)
-                 Initial 1 (base update)
+            * 5a32949 (gh/ezyang/1/base)
+            |    Initial 1 (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )
 

--- a/test/unlink/basic.py.test
+++ b/test/unlink/basic.py.test
@@ -67,7 +67,7 @@ else:
 
             This is commit A
 
-            * 55ee788 Initial 1
+            * bafc0db Initial 1
 
         [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
 
@@ -77,7 +77,7 @@ else:
 
             This is commit B
 
-            * a3419f5 Initial 1
+            * d96fc53 Initial 1
 
         [O] #502 Commit A (gh/ezyang/3/head -> gh/ezyang/3/base)
 
@@ -87,7 +87,7 @@ else:
 
             This is commit A
 
-            * ab3db60 Initial 2
+            * 12d35d5 Initial 2
 
         [O] #503 Commit B (gh/ezyang/4/head -> gh/ezyang/4/base)
 
@@ -97,25 +97,31 @@ else:
 
             This is commit B
 
-            * f30ebce Initial 2
+            * 9f380e7 Initial 2
 
         Repository state:
 
-            * 55ee788 (gh/ezyang/1/head)
+            * bafc0db (gh/ezyang/1/head)
             |    Initial 1
-            * 5434862 (gh/ezyang/1/base)
-                 Initial 1 (base update)
-            * a3419f5 (gh/ezyang/2/head)
-            |    Initial 1
-            * c66825d (gh/ezyang/2/base)
-                 Initial 1 (base update)
-            * ab3db60 (gh/ezyang/3/head)
-            |    Initial 2
-            * e957508 (gh/ezyang/3/base)
-                 Initial 2 (base update)
-            * f30ebce (gh/ezyang/4/head)
-            |    Initial 2
-            * 94673ed (gh/ezyang/4/base)
-                 Initial 2 (base update)
+            * 73a877d (gh/ezyang/1/base)
+            |    Initial 1 (base update)
+            | * d96fc53 (gh/ezyang/2/head)
+            | |    Initial 1
+            | * 20df153 (gh/ezyang/2/base)
+            | |    Initial 1 (base update)
+            | * c5f6953
+            |/     Commit A
+            | * 12d35d5 (gh/ezyang/3/head)
+            | |    Initial 2
+            | * f081adc (gh/ezyang/3/base)
+            |/     Initial 2 (base update)
+            | * 9f380e7 (gh/ezyang/4/head)
+            | |    Initial 2
+            | * 46cebf3 (gh/ezyang/4/base)
+            | |    Initial 2 (base update)
+            | * aefdf71
+            |/     Commit A
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
         """
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #241

Fixes https://github.com/ezyang/ghstack/issues/238

Signed-off-by: Edward Z. Yang <ezyang@meta.com>