### PR TITLE
Hotfix: properly prefix base with remote name

### DIFF
--- a/ghstack/submit.py
+++ b/ghstack/submit.py
@@ -1204,7 +1204,9 @@ is closed (likely due to being merged).  Please rebase to upstream and try again
                 # incorporate changes on base, and if a ghstack has been
                 # rebased backwards in time, the merge-base will be stuck
                 # on the more recent commit), it is useful so we put it in.
-                extra_base = self.sh.git("merge-base", base.commit_id, self.base)
+                extra_base = self.sh.git(
+                    "merge-base", base.commit_id, f"{self.remote_name}/{self.base}"
+                )
                 if push_branches.base.commit is None or not self.sh.git(
                     "merge-base",
                     "--is-ancestor",

--- a/test/land/update_after_land.py.test
+++ b/test/land/update_after_land.py.test
@@ -55,23 +55,23 @@ else:
 
             This is commit B
 
-            * 885020e Run 3
-            * d96fc53 Initial 1
+            * 2ffb7a7 Run 3
+            * 16e1e12 Initial 1
 
         Repository state:
 
-            *   885020e (gh/ezyang/2/head)
+            *   2ffb7a7 (gh/ezyang/2/head)
             |\\     Run 3
-            | *   1396fc7 (gh/ezyang/2/base)
+            | *   8ff40f5 (gh/ezyang/2/base)
             | |\\     Run 3 (base update)
+            | | * d6454e4 (HEAD -> master)
+            | | |    Commit A
             | | * 7f0288c
             | | |    Commit U
-            * | | d96fc53
+            * | | 16e1e12
             |/ /     Initial 1
-            * | 20df153
-            | |    Initial 1 (base update)
-            * | c5f6953
-            |/     Commit A
+            * / 9d4a439
+            |/     Initial 1 (base update)
             * dc8bfe4
                  Initial commit
         """

--- a/test/submit/amend_all.py.test
+++ b/test/submit/amend_all.py.test
@@ -67,8 +67,8 @@ else:
 
             This is commit B
 
-            * 3fb0bed Update A
-            * cfc0530 Initial 2
+            * 4050cf9 Update A
+            * ca4399f Initial 2
 
         Repository state:
 
@@ -78,16 +78,14 @@ else:
             |    Initial 1
             * 5a32949 (gh/ezyang/1/base)
             |    Initial 1 (base update)
-            | *   3fb0bed (gh/ezyang/2/head)
+            | *   4050cf9 (gh/ezyang/2/head)
             | |\\     Update A
-            | | * edd4564 (gh/ezyang/2/base)
+            | | * 390391f (gh/ezyang/2/base)
             | | |    Update A (base update)
-            | * | cfc0530
+            | * | ca4399f
             | |/     Initial 2
-            | * bf457db
-            | |    Initial 2 (base update)
-            | * 8b023bd
-            |/     Commit A
+            | * c05297f
+            |/     Initial 2 (base update)
             * dc8bfe4 (HEAD -> master)
                  Initial commit
         """

--- a/test/submit/amend_bottom.py.test
+++ b/test/submit/amend_bottom.py.test
@@ -67,21 +67,19 @@ else:
 
             This is commit B
 
-            * c11f047 Update B
-            * cfc0530 Initial 2
+            * b2f2161 Update B
+            * ca4399f Initial 2
 
         Repository state:
 
-            *   c11f047 (gh/ezyang/2/head)
+            *   b2f2161 (gh/ezyang/2/head)
             |\\     Update B
-            | * 7c6b228 (gh/ezyang/2/base)
+            | * 26f7790 (gh/ezyang/2/base)
             | |    Update B (base update)
-            * | cfc0530
+            * | ca4399f
             |/     Initial 2
-            * bf457db
+            * c05297f
             |    Initial 2 (base update)
-            * 8b023bd
-            |    Commit A
             | * 414cdf2 (gh/ezyang/1/head)
             | |    Update A
             | * 36fcfdf

--- a/test/submit/amend_top.py.test
+++ b/test/submit/amend_top.py.test
@@ -60,19 +60,17 @@ else:
 
             This is commit B
 
-            * 9a4a9ae Update A
-            * cfc0530 Initial 2
+            * 4bef30e Update A
+            * ca4399f Initial 2
 
         Repository state:
 
-            * 9a4a9ae (gh/ezyang/2/head)
+            * 4bef30e (gh/ezyang/2/head)
             |    Update A
-            * cfc0530
+            * ca4399f
             |    Initial 2
-            * bf457db (gh/ezyang/2/base)
+            * c05297f (gh/ezyang/2/base)
             |    Initial 2 (base update)
-            * 8b023bd
-            |    Commit A
             | * 36fcfdf (gh/ezyang/1/head)
             | |    Initial 1
             | * 5a32949 (gh/ezyang/1/base)

--- a/test/submit/empty_commit.py.test
+++ b/test/submit/empty_commit.py.test
@@ -17,16 +17,14 @@ else:
 
             This is commit B
 
-            * 50f7665 Initial
+            * ea3fb27 Initial
 
         Repository state:
 
-            * 50f7665 (gh/ezyang/1/head)
+            * ea3fb27 (gh/ezyang/1/head)
             |    Initial
-            * 23298b8 (gh/ezyang/1/base)
+            * 11e6d4d (gh/ezyang/1/base)
             |    Initial (base update)
-            * 31a6b65
-            |    Commit 1
             * dc8bfe4 (HEAD -> master)
                  Initial commit
         """

--- a/test/submit/multi.py.test
+++ b/test/submit/multi.py.test
@@ -50,7 +50,7 @@ else:
 
             This is commit B
 
-            * 9f28612 Initial 1 and 2
+            * 4b5463d Initial 1 and 2
 
         Repository state:
 
@@ -58,12 +58,10 @@ else:
             |    Initial 1 and 2
             * cc79b9e (gh/ezyang/1/base)
             |    Initial 1 and 2 (base update)
-            | * 9f28612 (gh/ezyang/2/head)
+            | * 4b5463d (gh/ezyang/2/head)
             | |    Initial 1 and 2
-            | * febf650 (gh/ezyang/2/base)
-            | |    Initial 1 and 2 (base update)
-            | * c5f6953
-            |/     Commit A
+            | * 954b129 (gh/ezyang/2/base)
+            |/     Initial 1 and 2 (base update)
             * dc8bfe4 (HEAD -> master)
                  Initial commit
         """

--- a/test/submit/no_clobber_carriage_returns.py.test
+++ b/test/submit/no_clobber_carriage_returns.py.test
@@ -119,16 +119,14 @@ else:
 
 
 
-            * 95915be Initial 2
+            * 95a2045 Initial 2
 
         Repository state:
 
-            * 95915be (gh/ezyang/2/head)
+            * 95a2045 (gh/ezyang/2/head)
             |    Initial 2
-            * 30049f9 (gh/ezyang/2/base)
+            * df3e13f (gh/ezyang/2/base)
             |    Initial 2 (base update)
-            * 6f81292
-            |    Commit 1
             | * 54d43aa (gh/ezyang/1/head)
             | |    Initial 1
             | * 5a32949 (gh/ezyang/1/base)

--- a/test/submit/reorder.py.test
+++ b/test/submit/reorder.py.test
@@ -64,8 +64,8 @@ else:
 
             This is commit B
 
-            * a9a3f2b Reorder
-            * f420265 Initial
+            * b242138 Reorder
+            * c9f59d4 Initial
 
         Repository state:
 
@@ -77,16 +77,14 @@ else:
             |/     Initial
             * 13c3cb3
             |    Initial (base update)
-            | *   a9a3f2b (gh/ezyang/2/head)
+            | *   b242138 (gh/ezyang/2/head)
             | |\\     Reorder
-            | | * 6d3e372 (gh/ezyang/2/base)
+            | | * d082148 (gh/ezyang/2/base)
             | | |    Reorder (base update)
-            | * | f420265
+            | * | c9f59d4
             | |/     Initial
-            | * 8e45110
-            | |    Initial (base update)
-            | * c5f6953
-            |/     Commit A
+            | * 8e6f9ba
+            |/     Initial (base update)
             * dc8bfe4 (HEAD -> master)
                  Initial commit
         """

--- a/test/submit/simple.py.test
+++ b/test/submit/simple.py.test
@@ -56,16 +56,14 @@ else:
 
             This is commit B
 
-            * cfc0530 Initial 2
+            * ca4399f Initial 2
 
         Repository state:
 
-            * cfc0530 (gh/ezyang/2/head)
+            * ca4399f (gh/ezyang/2/head)
             |    Initial 2
-            * bf457db (gh/ezyang/2/base)
+            * c05297f (gh/ezyang/2/base)
             |    Initial 2 (base update)
-            * 8b023bd
-            |    Commit A
             | * 36fcfdf (gh/ezyang/1/head)
             | |    Initial 1
             | * 5a32949 (gh/ezyang/1/base)

--- a/test/submit/unrelated_malformed_gh_branch_ok.py.test
+++ b/test/submit/unrelated_malformed_gh_branch_ok.py.test
@@ -64,16 +64,14 @@ else:
 
             This is commit B
 
-            * cfc0530 Initial 2
+            * ca4399f Initial 2
 
         Repository state:
 
-            * cfc0530 (gh/ezyang/2/head)
+            * ca4399f (gh/ezyang/2/head)
             |    Initial 2
-            * bf457db (gh/ezyang/2/base)
+            * c05297f (gh/ezyang/2/base)
             |    Initial 2 (base update)
-            * 8b023bd
-            |    Commit A
             | * 36fcfdf (gh/ezyang/1/head)
             | |    Initial 1
             | * 5a32949 (gh/ezyang/1/base)

--- a/test/unlink/basic.py.test
+++ b/test/unlink/basic.py.test
@@ -77,7 +77,7 @@ else:
 
             This is commit B
 
-            * d96fc53 Initial 1
+            * 16e1e12 Initial 1
 
         [O] #502 Commit A (gh/ezyang/3/head -> gh/ezyang/3/base)
 
@@ -97,7 +97,7 @@ else:
 
             This is commit B
 
-            * 9f380e7 Initial 2
+            * ca4399f Initial 2
 
         Repository state:
 
@@ -105,22 +105,18 @@ else:
             |    Initial 1
             * 73a877d (gh/ezyang/1/base)
             |    Initial 1 (base update)
-            | * d96fc53 (gh/ezyang/2/head)
+            | * 16e1e12 (gh/ezyang/2/head)
             | |    Initial 1
-            | * 20df153 (gh/ezyang/2/base)
-            | |    Initial 1 (base update)
-            | * c5f6953
-            |/     Commit A
+            | * 9d4a439 (gh/ezyang/2/base)
+            |/     Initial 1 (base update)
             | * 12d35d5 (gh/ezyang/3/head)
             | |    Initial 2
             | * f081adc (gh/ezyang/3/base)
             |/     Initial 2 (base update)
-            | * 9f380e7 (gh/ezyang/4/head)
+            | * ca4399f (gh/ezyang/4/head)
             | |    Initial 2
-            | * 46cebf3 (gh/ezyang/4/base)
-            | |    Initial 2 (base update)
-            | * aefdf71
-            |/     Commit A
+            | * c05297f (gh/ezyang/4/base)
+            |/     Initial 2 (base update)
             * dc8bfe4 (HEAD -> master)
                  Initial commit
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #242

Signed-off-by: Edward Z. Yang <ezyang@meta.com>