### PR TITLE
Parse PR number directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ branch, and start working on a fresh branch.
 
 **WARNING.**  You will NOT be able to merge these commits using the
 normal GitHub UI, as their branch bases won't be master.  Use
-`ghstack land $PR_URL` to land a ghstack'ed pull request.
+`ghstack land $PR_URL` (or alternatively `ghtstack land #PR_NUM`) to land
+a ghstack'ed pull request.
 
 ## Structure of submitted pull requests
 

--- a/ghstack/github_utils.py
+++ b/ghstack/github_utils.py
@@ -27,7 +27,7 @@ def get_github_repo_name_with_owner(
     # Grovel in remotes to figure it out
     remote_url = sh.git("remote", "get-url", remote_name)
     while True:
-        match = r"^git@{github_url}:([^/]+)/(.+?)(?:\.git)?$".format(
+        match = r"^git@{github_url}:/?([^/]+)/(.+?)(?:\.git)?$".format(
             github_url=github_url
         )
         m = re.match(match, remote_url)

--- a/ghstack/github_utils.py
+++ b/ghstack/github_utils.py
@@ -116,10 +116,10 @@ GitHubPullRequestParams = TypedDict(
 
 
 def parse_pull_request(
-        pull_request: str,
-        *,
-        sh: Optional[ghstack.shell.Shell] = None,
-        remote_name: Optional[str] = None,
+    pull_request: str,
+    *,
+    sh: Optional[ghstack.shell.Shell] = None,
+    remote_name: Optional[str] = None,
 ) -> GitHubPullRequestParams:
     m = RE_PR_URL.match(pull_request)
     if not m:

--- a/ghstack/land.py
+++ b/ghstack/land.py
@@ -57,7 +57,7 @@ def main(
     # Furthermore, the parent commits of PR are ignored: we always
     # take the canonical version of the patch from any given pr
 
-    params = ghstack.github_utils.parse_pull_request(pull_request)
+    params = ghstack.github_utils.parse_pull_request(pull_request, sh=sh, remote_name=remote_name)
     default_branch = ghstack.github_utils.get_github_repo_info(
         github=github,
         sh=sh,

--- a/ghstack/land.py
+++ b/ghstack/land.py
@@ -57,7 +57,9 @@ def main(
     # Furthermore, the parent commits of PR are ignored: we always
     # take the canonical version of the patch from any given pr
 
-    params = ghstack.github_utils.parse_pull_request(pull_request, sh=sh, remote_name=remote_name)
+    params = ghstack.github_utils.parse_pull_request(
+        pull_request, sh=sh, remote_name=remote_name
+    )
     default_branch = ghstack.github_utils.get_github_repo_info(
         github=github,
         sh=sh,


### PR DESCRIPTION
Allows for 
```
ghstack land 1234
```
instead of 
```
ghstack land https://github.com/origin/repo/pull/1234
```

I guess we could do the same with checkout and such - LMK if I should do a single PR or a PR stack with these!