### PR TITLE
Make Pull-Request-resolved hyphenated to be valid trailer

### DIFF
--- a/src/ghstack/diff.py
+++ b/src/ghstack/diff.py
@@ -14,7 +14,7 @@ RE_GH_METADATA = re.compile(
 
 
 RAW_PULL_REQUEST_RESOLVED = (
-    r"Pull Request resolved: "
+    r"(Pull Request resolved|Pull-Request-resolved): "
     r"https://{github_url}/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>[0-9]+)"
 )
 
@@ -93,7 +93,7 @@ class Diff:
     # be the same.
     source_id: str
 
-    # The contents of 'Pull Request resolved'.  This is None for
+    # The contents of 'Pull-Request-resolved'.  This is None for
     # diffs that haven't been submitted by ghstack.  For BC reasons,
     # this also accepts gh-metadata.
     pull_request_resolved: Optional[PullRequestResolved]

--- a/src/ghstack/submit.py
+++ b/src/ghstack/submit.py
@@ -815,7 +815,7 @@ as it supports bidirectional syncing.  However, there is no way to
 convert a pre-existing PR in the old style to the new format which
 supports bidirectional syncing.  If you would like to blow away the old
 PR and start anew, edit the Summary in the Phabricator diff to delete
-the line 'Pull Request resolved' and then run ghexport again.
+the line 'Pull-Request-resolved' and then run ghexport again.
 """
             )
 
@@ -832,7 +832,7 @@ the Phabricator diff page?  If so, please continue to use that button
 to export your diff.
 
 If you think this is in error, edit the Summary in the Phabricator diff
-to delete the line 'Pull Request resolved' and then run ghexport again.
+to delete the line 'Pull-Request-resolved' and then run ghexport again.
 """
                 )
             else:
@@ -963,17 +963,20 @@ to disassociate the commit with the pull request, and then try again.
             commit_msg = self._update_source_id(diff.summary, elab_diff)
         else:
             # Need to insert metadata for the first time
-            commit_msg = "".join(
-                [
-                    f"{strip_mentions(diff.summary.rstrip())}\n\n",
-                    f"ghstack-source-id: {diff.source_id}\n",
-                    (
-                        f"ghstack-comment-id: {elab_diff.comment_id}\n"
-                        if self.direct
-                        else ""
-                    ),
-                    f"Pull Request resolved: {pull_request_resolved.url()}",
-                ]
+            # TODO: Probably quicker if we reimplement reinterpret-trailers
+            # in Python
+            commit_msg = self.sh.git(
+                "interpret-trailers",
+                "--trailer",
+                f"ghstack-source-id: {diff.source_id}",
+                *(
+                    ["--trailer", f"ghstack-comment-id: {elab_diff.comment_id}"]
+                    if self.direct
+                    else []
+                ),
+                "--trailer",
+                f"Pull-Request-resolved: {pull_request_resolved.url()}",
+                input=strip_mentions(diff.summary.rstrip()),
             )
 
         return DiffMeta(

--- a/test/land/default_branch_change.py.test
+++ b/test/land/default_branch_change.py.test
@@ -48,7 +48,7 @@ assert_expected_inline(
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "main"),
     """\
-8b023bd Commit A
+6f717c4 Commit A
 dc8bfe4 Initial commit""",
 )
 
@@ -82,15 +82,15 @@ assert_github_state(
 
             This is commit B
 
-            * cfc0530 Initial 2
+            * 53a3584 Initial 2
 
         Repository state:
 
-            * cfc0530 (gh/ezyang/2/head)
+            * 53a3584 (gh/ezyang/2/head)
             |    Initial 2
-            * bf457db (gh/ezyang/2/base)
+            * c55ff15 (gh/ezyang/2/base)
             |    Initial 2 (base update)
-            * 8b023bd (main, gh/ezyang/1/orig)
+            * 6f717c4 (main, gh/ezyang/1/orig)
             |    Commit A
             | * 36fcfdf (gh/ezyang/1/head)
             | |    Initial 1
@@ -107,13 +107,13 @@ gh_land(diff2.pr_url)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-a677f4e Commit B
-8f51278 Commit A
+35747c0 Commit B
+b2ec056 Commit A
 dc8bfe4 Initial commit""",
 )
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "main"),
     """\
-8b023bd Commit A
+6f717c4 Commit A
 dc8bfe4 Initial commit""",
 )

--- a/test/land/ff.py.test
+++ b/test/land/ff.py.test
@@ -11,7 +11,7 @@ gh_land(pr_url)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-8b023bd Commit A
+6f717c4 Commit A
 dc8bfe4 Initial commit""",
 )
 

--- a/test/land/ff_stack.py.test
+++ b/test/land/ff_stack.py.test
@@ -16,7 +16,7 @@ gh_land(pr_url)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-b2d9b84 Commit B
-fe65c88 Commit A
+2f2f3f6 Commit B
+3db0d3b Commit A
 dc8bfe4 Initial commit""",
 )

--- a/test/land/ff_stack_two_phase.py.test
+++ b/test/land/ff_stack_two_phase.py.test
@@ -18,7 +18,7 @@ gh_land(pr_url2)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-b2d9b84 Commit B
-fe65c88 Commit A
+2f2f3f6 Commit B
+3db0d3b Commit A
 dc8bfe4 Initial commit""",
 )

--- a/test/land/invalid_resubmit.py.test
+++ b/test/land/invalid_resubmit.py.test
@@ -11,7 +11,7 @@ pr_url = diff.pr_url
 gh_land(pr_url)
 
 write_file_and_add("file2.txt", "A")
-git("commit", "--amend")
+git("commit", "--amend", "--no-edit")
 assert_expected_raises_inline(
     RuntimeError,
     lambda: gh_submit("Update"),
@@ -44,15 +44,15 @@ else:
 
             This is commit A
 
-            * edc8acf New PR
+            * f014df7 New PR
 
         Repository state:
 
-            * edc8acf (gh/ezyang/1/head)
+            * f014df7 (gh/ezyang/1/head)
             |    New PR
-            * b38da4f (gh/ezyang/1/base)
+            * 69e4b60 (gh/ezyang/1/base)
             |    New PR (base update)
-            * 8b023bd (HEAD -> master)
+            * 6f717c4 (HEAD -> master)
             |    Commit A
             * dc8bfe4
                  Initial commit

--- a/test/land/non_ff.py.test
+++ b/test/land/non_ff.py.test
@@ -17,7 +17,7 @@ gh_land(pr_url)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-a3996ab Commit A
+b327b28 Commit A
 38808c0 Commit U
 dc8bfe4 Initial commit""",
 )

--- a/test/land/non_ff_stack_two_phase.py.test
+++ b/test/land/non_ff_stack_two_phase.py.test
@@ -22,8 +22,8 @@ gh_land(pr_url2)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-643692e Commit B
-3a731f4 Commit A
+c86afe5 Commit B
+30e22bc Commit A
 a8ca27f Commit C
 dc8bfe4 Initial commit""",
 )

--- a/test/land/update_after_land.py.test
+++ b/test/land/update_after_land.py.test
@@ -55,16 +55,16 @@ else:
 
             This is commit B
 
-            * 2ffb7a7 Run 3
+            * 7d34855 Run 3
             * 16e1e12 Initial 1
 
         Repository state:
 
-            *   2ffb7a7 (gh/ezyang/2/head)
+            *   7d34855 (gh/ezyang/2/head)
             |\\     Run 3
-            | *   8ff40f5 (gh/ezyang/2/base)
+            | *   9a04232 (gh/ezyang/2/base)
             | |\\     Run 3 (base update)
-            | | * d6454e4 (HEAD -> master)
+            | | * 16f0d55 (HEAD -> master)
             | | |    Commit A
             | | * 7f0288c
             | | |    Commit U

--- a/test/submit/do_not_revert_local_commit_msg_on_skip.py.test
+++ b/test/submit/do_not_revert_local_commit_msg_on_skip.py.test
@@ -17,7 +17,7 @@ if is_direct():
 
         ghstack-source-id: ac00f28640afe01e4299441bb5041cdf06d0b6b4
         ghstack-comment-id: 1500
-        Pull Request resolved: https://github.com/pytorch/pytorch/pull/500""",
+        Pull-Request-resolved: https://github.com/pytorch/pytorch/pull/500""",
     )
 else:
     assert_expected_inline(
@@ -28,7 +28,7 @@ else:
         This is commit ARGLE
 
         ghstack-source-id: ac00f28640afe01e4299441bb5041cdf06d0b6b4
-        Pull Request resolved: https://github.com/pytorch/pytorch/pull/500""",
+        Pull-Request-resolved: https://github.com/pytorch/pytorch/pull/500""",
     )
 
 if is_direct():

--- a/test/submit/strip_mentions.py.test
+++ b/test/submit/strip_mentions.py.test
@@ -44,10 +44,9 @@ if is_direct():
         This is my first commit, hello foobar Ivan
 
         Signed-off-by: foo@gmail.com
-
         ghstack-source-id: ddf506901b8d3c2b4079ec39e564f19bd5468397
         ghstack-comment-id: 1500
-        Pull Request resolved: https://github.com/pytorch/pytorch/pull/500""",
+        Pull-Request-resolved: https://github.com/pytorch/pytorch/pull/500""",
     )
 else:
     assert_expected_inline(
@@ -60,7 +59,6 @@ else:
         This is my first commit, hello foobar Ivan
 
         Signed-off-by: foo@gmail.com
-
         ghstack-source-id: ddf506901b8d3c2b4079ec39e564f19bd5468397
-        Pull Request resolved: https://github.com/pytorch/pytorch/pull/500""",
+        Pull-Request-resolved: https://github.com/pytorch/pytorch/pull/500""",
     )

--- a/uv.lock
+++ b/uv.lock
@@ -630,7 +630,7 @@ wheels = [
 
 [[package]]
 name = "ghstack"
-version = "0.9.5"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp", version = "3.10.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
Previously, we used the syntax "Pull Request resolved", however,
this is not a valid Git trailer as there are spaces in the key.
Replacing the spaces with hyphens fixes this, while not impeding
GitHub's auto-resolve capabilities (as it only matches for resolved
at the tail of the string).

I also use git interpret-trailers to handle trailer modification,
which makes ghstack more robust when there are pre-existing trailers
in the commit message (as all trailers must be together in a blog,
there must not be any double newlines.)

Signed-off-by: Edward Z. Yang <ezyang@mit.edu>
Pull-Request-resolved: https://github.com/ezyang/ghstack/pull/278