### PR TITLE
Add `--no-verify` to ghstack submission

### DIFF
--- a/src/ghstack/submit.py
+++ b/src/ghstack/submit.py
@@ -1801,6 +1801,7 @@ is closed (likely due to being merged).  Please rebase to upstream and try again
             self.sh.git(
                 "push",
                 self.remote_name,
+                "--no-verify",
                 *(["--force"] if force else []),
                 *branches,
             )


### PR DESCRIPTION
If 

1. you have pre-commit hooks
2. As part of your rebase you break pre-commit hooks (which don't run on rebases!). Or alternately you locally do a commit with `--no-verify`
3. You run `ghstack`

Then, `ghstack` fails with an error like
```
$ git commit-tree -p c4f05f3f02d4523f99ba0fd5b6a80eef03ea3be2 ccf059a081a7f086252c77ae3edfeee8845a2246
$ git commit-tree -p 54f88cde23b09c8e9d0c15cea04677deba04d37c e858f7a23e46b586a511222661ed8f3902da344a
$ git push origin 54f88cde23b09c8e9d0c15cea04677deba04d37c:refs/heads/gh/chillee/58/base 51d6f0469e788e120698546861ff9178eaebcee3:refs/heads/gh/chillee/58/head
error: failed to push some refs to 'github.com:iterationlab/monorepo.git'
$ git remote get-url --push origin
ERROR: Fatal exception
Traceback (most recent call last):
  File "/tmp/horace/uv-venv/lib/python3.12/site-packages/ghstack/logs.py", line 105, in manager
    yield
  File "/tmp/horace/uv-venv/lib/python3.12/site-packages/ghstack/cli.py", line 46, in cli_context
    yield shell, config, github
  File "/tmp/horace/uv-venv/lib/python3.12/site-packages/ghstack/cli.py", line 258, in submit
    ghstack.submit.main(
  File "/tmp/horace/uv-venv/lib/python3.12/site-packages/ghstack/submit.py", line 261, in main
    return submitter.run()
           ^^^^^^^^^^^^^^^
  File "/tmp/horace/uv-venv/lib/python3.12/site-packages/ghstack/submit.py", line 511, in run
    diff_meta_index, rebase_index = self.prepare_updates(
                                    ^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/horace/uv-venv/lib/python3.12/site-packages/ghstack/submit.py", line 704, in prepare_updates
    diff_meta = self.process_commit(
                ^^^^^^^^^^^^^^^^^^^^
  File "/tmp/horace/uv-venv/lib/python3.12/site-packages/ghstack/submit.py", line 942, in process_commit
    self._git_push(
  File "/tmp/horace/uv-venv/lib/python3.12/site-packages/ghstack/submit.py", line 1797, in _git_push
    self.sh.git(
  File "/tmp/horace/uv-venv/lib/python3.12/site-packages/ghstack/shell.py", line 281, in git
    return self._maybe_rstrip(self.sh(*(("git",) + args), **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/horace/uv-venv/lib/python3.12/site-packages/ghstack/shell.py", line 220, in sh
    raise RuntimeError(
RuntimeError: git push origin 54f88cde23b09c8e9d0c15cea04677deba04d37c:refs/heads/gh/chillee/58/base 51d6f0469e788e120698546861ff9178eaebcee3:refs/heads/gh/chillee/58/head failed with exit code 1
```

As part of `ghstack`, I think we should _never_ care about precommit hooks failing. If precommit hooks are failing then users should then fix them manually. It can also leave the ghstack submit in a somewhat poor spot (e.g. half of the ghstack PRs opened but not the rest).

So, I added `--no-verify` to `submit.py`'s push.

