### PR TITLE
refactor: replace git interpret-trailers with Python implementation

### DIFF
--- a/src/ghstack/land.py
+++ b/src/ghstack/land.py
@@ -168,7 +168,9 @@ to complain to the ghstack authors."""
             # TODO: regex here so janky
             base_ref = re.sub(r"/orig$", "/base", orig_ref)
             head_ref = re.sub(r"/orig$", "/head", orig_ref)
-            sh.git("push", remote_name, f"{remote_name}/{head_ref}:refs/heads/{base_ref}")
+            sh.git(
+                "push", remote_name, f"{remote_name}/{head_ref}:refs/heads/{base_ref}"
+            )
             github.notify_merged(pr_resolved)
 
         # All good! Push!

--- a/src/ghstack/submit.py
+++ b/src/ghstack/submit.py
@@ -970,11 +970,12 @@ to disassociate the commit with the pull request, and then try again.
             if self.direct:
                 trailers_to_add.append(f"ghstack-comment-id: {elab_diff.comment_id}")
 
-            trailers_to_add.append(f"Pull-Request-resolved: {pull_request_resolved.url()}")
+            trailers_to_add.append(
+                f"Pull-Request-resolved: {pull_request_resolved.url()}"
+            )
 
             commit_msg = ghstack.trailers.interpret_trailers(
-                strip_mentions(diff.summary.rstrip()),
-                trailers_to_add
+                strip_mentions(diff.summary.rstrip()), trailers_to_add
             )
 
         return DiffMeta(

--- a/src/ghstack/submit.py
+++ b/src/ghstack/submit.py
@@ -15,6 +15,7 @@ import ghstack.github_utils
 import ghstack.gpg_sign
 import ghstack.logs
 import ghstack.shell
+import ghstack.trailers
 from ghstack.types import GhNumber, GitCommitHash, GitHubNumber, GitHubRepositoryId
 
 # Either "base", "head" or "orig"; which of the ghstack generated
@@ -963,20 +964,17 @@ to disassociate the commit with the pull request, and then try again.
             commit_msg = self._update_source_id(diff.summary, elab_diff)
         else:
             # Need to insert metadata for the first time
-            # TODO: Probably quicker if we reimplement reinterpret-trailers
-            # in Python
-            commit_msg = self.sh.git(
-                "interpret-trailers",
-                "--trailer",
-                f"ghstack-source-id: {diff.source_id}",
-                *(
-                    ["--trailer", f"ghstack-comment-id: {elab_diff.comment_id}"]
-                    if self.direct
-                    else []
-                ),
-                "--trailer",
-                f"Pull-Request-resolved: {pull_request_resolved.url()}",
-                input=strip_mentions(diff.summary.rstrip()),
+            # Using our Python implementation of interpret-trailers
+            trailers_to_add = [f"ghstack-source-id: {diff.source_id}"]
+
+            if self.direct:
+                trailers_to_add.append(f"ghstack-comment-id: {elab_diff.comment_id}")
+
+            trailers_to_add.append(f"Pull-Request-resolved: {pull_request_resolved.url()}")
+
+            commit_msg = ghstack.trailers.interpret_trailers(
+                strip_mentions(diff.summary.rstrip()),
+                trailers_to_add
             )
 
         return DiffMeta(

--- a/src/ghstack/trailers.py
+++ b/src/ghstack/trailers.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+
+import re
+from typing import List, Tuple
+
+# Compile regexes once at module level for better performance
+TRAILER_RE = re.compile(r"^([A-Za-z0-9_-]+)(\s*:\s*)(.*)$")
+CONTINUATION_RE = re.compile(r"^\s+\S.*$")
+
+# Git-generated trailer prefixes
+GIT_GENERATED_PREFIXES = ["Signed-off-by: ", "(cherry picked from commit "]
+
+
+def parse_message(message: str) -> Tuple[str, str, str]:
+    """
+    Parse a Git commit message into subject, body, and trailers.
+
+    According to the Git documentation, trailers are:
+    - A group of one or more lines that is all trailers, or contains at least one
+      Git-generated or user-configured trailer and consists of at least 25% trailers.
+    - The group must be preceded by one or more empty (or whitespace-only) lines.
+    - The group must either be at the end of the message or be the last non-whitespace
+      lines before a line that starts with "---" (the "divider").
+
+    Args:
+        message: The commit message to parse.
+
+    Returns:
+        A tuple containing:
+            - subject: The first line of the message
+            - body: The body of the message (may be empty)
+            - trailers: The trailer block as a raw string (may be empty)
+    """
+    if not message:
+        return "", "", ""
+
+    # Split into lines and get the subject (first line)
+    lines = message.splitlines()
+    subject = lines[0] if lines else ""
+
+    if len(lines) <= 1:
+        return subject, "", ""
+
+    # Remove subject
+    message_lines = lines[1:]
+
+    if not message_lines:
+        return subject, "", ""
+
+    # Find where the trailer block starts
+    trailer_start = find_trailer_block_start(message_lines)
+
+    if trailer_start == -1:
+        # No trailer block found, everything after subject is body
+        body = "\n".join(message_lines).strip()
+        return subject, body, ""
+
+    # Body is everything between subject and trailers (with empty lines trimmed)
+    body = "\n".join(message_lines[:trailer_start]).strip()
+
+    # Keep trailers as a raw string
+    trailers = "\n".join(message_lines[trailer_start:]).strip()
+
+    return subject, body, trailers
+
+
+def find_trailer_block_start(lines: List[str]) -> int:
+    """
+    Find the start index of the trailer block in a list of lines.
+
+    Args:
+        lines: List of message lines (without subject and divider).
+
+    Returns:
+        Index of the first line of the trailer block, or -1 if no trailer block is found.
+    """
+    # Remove trailing empty lines
+    trimmed_lines = list(reversed([line for line in reversed(lines) if line.strip()]))
+
+    if not trimmed_lines:
+        return -1
+
+    # Find the last non-empty block
+    block_indices = [-1] + [i for i, line in enumerate(lines) if not line.strip()]
+
+    # Try blocks from last to first
+    for i in range(len(block_indices) - 1, -1, -1):
+        start_idx = block_indices[i] + 1
+        # If we're at the beginning or checking the whole message
+        if i == 0 or start_idx == 0:
+            # Check if the whole remaining content is a trailer block
+            if is_trailer_block(lines[start_idx:]):
+                return start_idx
+            # No more blocks to check
+            return -1
+
+        # Check if the block after this blank line is a trailer block
+        end_idx = block_indices[i + 1] if i + 1 < len(block_indices) else len(lines)
+        if is_trailer_block(lines[start_idx:end_idx]):
+            return start_idx
+
+    return -1
+
+
+def is_trailer_block(lines: List[str]) -> bool:
+    """
+    Determine if the given lines form a trailer block.
+
+    A block is a trailer block if:
+    1. All lines are trailers, or
+    2. At least one Git-generated trailer exists and at least 25% of lines are trailers
+
+    Args:
+        lines: List of lines to check.
+
+    Returns:
+        True if the lines form a trailer block, False otherwise.
+    """
+    # Filter out empty lines
+    content_lines = [line for line in lines if line.strip()]
+
+    if not content_lines:
+        return False
+
+    trailer_lines = 0
+    non_trailer_lines = 0
+    has_git_generated_trailer = False
+
+    i = 0
+    while i < len(content_lines):
+        line = content_lines[i]
+
+        # Skip continuation lines (they belong to the previous trailer)
+        if CONTINUATION_RE.match(line):
+            i += 1
+            continue
+
+        # Check if it's a git-generated trailer
+        if any(line.startswith(prefix) for prefix in GIT_GENERATED_PREFIXES):
+            has_git_generated_trailer = True
+            trailer_lines += 1
+        elif TRAILER_RE.match(line):
+            # Regular trailer
+            trailer_lines += 1
+        else:
+            # Not a trailer line
+            non_trailer_lines += 1
+
+        i += 1
+
+    # A block is a trailer block if all lines are trailers OR
+    # it has at least one git-generated trailer and >= 25% of lines are trailers
+    return (trailer_lines > 0 and non_trailer_lines == 0) or (
+        has_git_generated_trailer and trailer_lines * 3 >= non_trailer_lines
+    )
+
+
+def interpret_trailers(message: str, trailers_to_add: List[str]) -> str:
+    """
+    Add trailers to a commit message, mimicking git interpret-trailers.
+
+    Args:
+        message: The commit message to add trailers to
+        trailers_to_add: List of trailers to add in the format "Key: Value"
+
+    Returns:
+        The commit message with trailers added
+    """
+    subject, body, existing_trailers = parse_message(message)
+
+    # Create a new list with all trailers (existing + new)
+    all_trailers = []
+    if existing_trailers:
+        all_trailers.append(existing_trailers)
+
+    all_trailers.extend(trailers_to_add)
+
+    # Build the new message
+    new_message = subject
+
+    if body:
+        new_message += "\n\n" + body
+
+    if all_trailers:
+        if body or (not body and existing_trailers):
+            new_message += "\n"
+        if not existing_trailers:
+            new_message += "\n"
+        new_message += "\n" + "\n".join(all_trailers)
+
+    return new_message

--- a/test/land/default_branch_change.py.test
+++ b/test/land/default_branch_change.py.test
@@ -48,7 +48,7 @@ assert_expected_inline(
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "main"),
     """\
-6f717c4 Commit A
+19fa5fa Commit A
 dc8bfe4 Initial commit""",
 )
 
@@ -82,15 +82,15 @@ assert_github_state(
 
             This is commit B
 
-            * 53a3584 Initial 2
+            * f5135dc Initial 2
 
         Repository state:
 
-            * 53a3584 (gh/ezyang/2/head)
+            * f5135dc (gh/ezyang/2/head)
             |    Initial 2
-            * c55ff15 (gh/ezyang/2/base)
+            * 61e5c2a (gh/ezyang/2/base)
             |    Initial 2 (base update)
-            * 6f717c4 (main, gh/ezyang/1/orig)
+            * 19fa5fa (main, gh/ezyang/1/orig)
             |    Commit A
             | * 36fcfdf (gh/ezyang/1/head)
             | |    Initial 1
@@ -107,13 +107,13 @@ gh_land(diff2.pr_url)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-35747c0 Commit B
-b2ec056 Commit A
+19e7996 Commit B
+cb4e674 Commit A
 dc8bfe4 Initial commit""",
 )
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "main"),
     """\
-6f717c4 Commit A
+19fa5fa Commit A
 dc8bfe4 Initial commit""",
 )

--- a/test/land/ff.py.test
+++ b/test/land/ff.py.test
@@ -11,7 +11,7 @@ gh_land(pr_url)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-6f717c4 Commit A
+19fa5fa Commit A
 dc8bfe4 Initial commit""",
 )
 

--- a/test/land/ff_stack.py.test
+++ b/test/land/ff_stack.py.test
@@ -16,7 +16,7 @@ gh_land(pr_url)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-2f2f3f6 Commit B
-3db0d3b Commit A
+3c9c5eb Commit B
+6eb4d4f Commit A
 dc8bfe4 Initial commit""",
 )

--- a/test/land/ff_stack_two_phase.py.test
+++ b/test/land/ff_stack_two_phase.py.test
@@ -18,7 +18,7 @@ gh_land(pr_url2)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-2f2f3f6 Commit B
-3db0d3b Commit A
+3c9c5eb Commit B
+6eb4d4f Commit A
 dc8bfe4 Initial commit""",
 )

--- a/test/land/invalid_resubmit.py.test
+++ b/test/land/invalid_resubmit.py.test
@@ -44,15 +44,15 @@ else:
 
             This is commit A
 
-            * f014df7 New PR
+            * c461f2f New PR
 
         Repository state:
 
-            * f014df7 (gh/ezyang/1/head)
+            * c461f2f (gh/ezyang/1/head)
             |    New PR
-            * 69e4b60 (gh/ezyang/1/base)
+            * 58e6f57 (gh/ezyang/1/base)
             |    New PR (base update)
-            * 6f717c4 (HEAD -> master)
+            * 19fa5fa (HEAD -> master)
             |    Commit A
             * dc8bfe4
                  Initial commit

--- a/test/land/non_ff.py.test
+++ b/test/land/non_ff.py.test
@@ -17,7 +17,7 @@ gh_land(pr_url)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-b327b28 Commit A
+1d53e04 Commit A
 38808c0 Commit U
 dc8bfe4 Initial commit""",
 )

--- a/test/land/non_ff_stack_two_phase.py.test
+++ b/test/land/non_ff_stack_two_phase.py.test
@@ -22,8 +22,8 @@ gh_land(pr_url2)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-c86afe5 Commit B
-30e22bc Commit A
+613567d Commit B
+4dfc330 Commit A
 a8ca27f Commit C
 dc8bfe4 Initial commit""",
 )

--- a/test/land/update_after_land.py.test
+++ b/test/land/update_after_land.py.test
@@ -55,16 +55,16 @@ else:
 
             This is commit B
 
-            * 7d34855 Run 3
+            * 48dc874 Run 3
             * 16e1e12 Initial 1
 
         Repository state:
 
-            *   7d34855 (gh/ezyang/2/head)
+            *   48dc874 (gh/ezyang/2/head)
             |\\     Run 3
-            | *   9a04232 (gh/ezyang/2/base)
+            | *   5a46f58 (gh/ezyang/2/base)
             | |\\     Run 3 (base update)
-            | | * 16f0d55 (HEAD -> master)
+            | | * 30a9800 (HEAD -> master)
             | | |    Commit A
             | | * 7f0288c
             | | |    Commit U

--- a/test/unlink/basic.py.test
+++ b/test/unlink/basic.py.test
@@ -32,11 +32,13 @@ if is_direct():
 
 
 
+
             * 2193fd2 Initial 2
 
         [O] #503 Commit B (gh/ezyang/4/head -> gh/ezyang/3/head)
 
             This is commit B
+
 
 
 


### PR DESCRIPTION
replace the call to git interpret-trailers in ghstack/submit.py with this Python implementation attached.

```git-revs
341015d  (Base revision)
00e18c6  Create trailers.py module with the Python implementation of Git's interpret-trailers functionality
c24a648  Import the trailers module in submit.py
HEAD     Replace git interpret-trailers call with Python implementation
```

codemcp-id: 2-refactor-replace-git-interpret-trailers-with-pytho