### PR TITLE
Update land.py to delete head ref separately from orig ref and base ref

### DIFF
--- a/src/ghstack/land.py
+++ b/src/ghstack/land.py
@@ -187,7 +187,13 @@ to complain to the ghstack authors."""
             base_ref = re.sub(r"/orig$", "/base", orig_ref)
             head_ref = re.sub(r"/orig$", "/head", orig_ref)
             try:
-                sh.git("push", remote_name, "--delete", orig_ref, base_ref, head_ref)
+                sh.git("push", remote_name, "--delete", orig_ref, base_ref)
+            except RuntimeError:
+                # Whatever, keep going
+                logging.warning("Failed to delete branch, continuing", exc_info=True)
+            # Try deleting head_ref separately since often after it's merged it doesn't exist anymore
+            try:
+                sh.git("push", remote_name, "--delete", head_ref)
             except RuntimeError:
                 # Whatever, keep going
                 logging.warning("Failed to delete branch, continuing", exc_info=True)


### PR DESCRIPTION
I think after the merge the head branch is supposed(?) to be deleted, so git bails out on the whole command, not deleting any branches.

In principle I think we can just avoid deleting the head ref altogether but Chesterton's fence and all that.