### PR TITLE
Update ghstack to 0.10.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "flake8<8.0.0,>=7.0.0",
 ]
 name = "ghstack"
-version = "0.10.0"
+version = "0.10.1"
 description = "Stack diff support for GitHub"
 readme = "README.md"
 classifiers = [


### PR DESCRIPTION
Main features are:
1. More robust branch deletion
2. Fixing a race where if main was updated after the branch was rebased but before the push it would close the PR but unsuccessfully merge.
3. Supporting more than 8 stacked PRs through throttling PR creation.