### PR TITLE
Print ghstack version in PR description

### DIFF
--- a/src/ghstack/submit.py
+++ b/src/ghstack/submit.py
@@ -168,7 +168,7 @@ def strip_mentions(body: str) -> str:
 
 
 STACK_HEADER = (
-    "Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom)"
+    f"Stack from [ghstack](https://github.com/ezyang/ghstack) {ghstack.__version__} (oldest at bottom)"
 )
 
 

--- a/src/ghstack/submit.py
+++ b/src/ghstack/submit.py
@@ -167,9 +167,7 @@ def strip_mentions(body: str) -> str:
     return RE_MENTION.sub(r"\1", body)
 
 
-STACK_HEADER = (
-    f"Stack from [ghstack](https://github.com/ezyang/ghstack) {ghstack.__version__} (oldest at bottom)"
-)
+STACK_HEADER = f"Stack from [ghstack](https://github.com/ezyang/ghstack/tree/{ghstack.__version__}) (oldest at bottom)"
 
 
 def starts_with_bullet(body: str) -> bool:


### PR DESCRIPTION
We have an issue in https://github.com/pytorch/pytorch/issues/154427#issuecomment-2940623897 where people reportedly used an older version of ghstack which made a new PR on the same commit.  An easy way to debug this issue in the future is to mention the ghstack version that is used to create the stack in the PR description itself.

I add the version into the URL to make it less intrusive.

### Testing

https://github.com/pytorch/pytorch/pull/155179#issue-3119502241