### PR TITLE
Allow using `-h` for help

### DIFF
--- a/src/ghstack/cli.py
+++ b/src/ghstack/cli.py
@@ -48,7 +48,7 @@ def cli_context(
         yield shell, config, github
 
 
-@click.group(invoke_without_command=True)
+@click.group(invoke_without_command=True, context_settings={"help_option_names": ["-h", "--help"]})
 @click.pass_context
 @click.version_option(ghstack.__version__, "--version", "-V")
 @click.option("--debug", is_flag=True, help="Log debug information to stderr")

--- a/src/ghstack/cli.py
+++ b/src/ghstack/cli.py
@@ -48,7 +48,10 @@ def cli_context(
         yield shell, config, github
 
 
-@click.group(invoke_without_command=True, context_settings={"help_option_names": ["-h", "--help"]})
+@click.group(
+    invoke_without_command=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 @click.pass_context
 @click.version_option(ghstack.__version__, "--version", "-V")
 @click.option("--debug", is_flag=True, help="Log debug information to stderr")


### PR DESCRIPTION
It's common to support both `-h` and `--help`. I often find myself using `ghstack -h` and hitting an error.