### PR TITLE
Add PR number during PR creation instead of land

### DIFF
--- a/src/ghstack/land.py
+++ b/src/ghstack/land.py
@@ -145,40 +145,12 @@ to complain to the ghstack authors."""
             stack_orig_refs.append((ref, pr_resolved))
 
         # OK, actually do the land now
-        for orig_ref, pr_resolved in stack_orig_refs:
+        for orig_ref, _ in stack_orig_refs:
             try:
                 sh.git("cherry-pick", f"{remote_name}/{orig_ref}")
             except BaseException:
                 sh.git("cherry-pick", "--abort")
                 raise
-
-            # Add PR number to commit message like GitHub does
-            commit_msg = sh.git("log", "-1", "--pretty=%B")
-            # Get the original author and committer dates to preserve the commit hash
-            author_date = sh.git("log", "-1", "--pretty=%aD")
-            committer_date = sh.git("log", "-1", "--pretty=%cD")
-            lines = commit_msg.split("\n")
-            if lines:
-                # Add PR number to the subject line (first line)
-                subject = lines[0].rstrip()
-                # Only add if not already present
-                pr_tag = f"(#{pr_resolved.number})"
-                if pr_tag not in subject:
-                    subject = f"{subject} {pr_tag}"
-                lines[0] = subject
-                new_msg = "\n".join(lines)
-                # Preserve dates to keep the commit hash consistent
-                sh.git(
-                    "commit",
-                    "--amend",
-                    "-F",
-                    "-",
-                    input=new_msg,
-                    env={
-                        "GIT_AUTHOR_DATE": author_date,
-                        "GIT_COMMITTER_DATE": committer_date,
-                    },
-                )
 
         # All good! Push!
         maybe_force_arg = []

--- a/src/ghstack/submit.py
+++ b/src/ghstack/submit.py
@@ -1017,9 +1017,18 @@ to disassociate the commit with the pull request, and then try again.
 
             trailers_to_add.append(f"Pull-Request: {pull_request_resolved.url()}")
 
-            commit_msg = ghstack.trailers.interpret_trailers(
-                strip_mentions(diff.summary.rstrip()), trailers_to_add
-            )
+            # Add PR number to the commit subject line, like GitHub does
+            summary = strip_mentions(diff.summary.rstrip())
+            lines = summary.split("\n")
+            if lines:
+                subject = lines[0].rstrip()
+                pr_tag = f"(#{elab_diff.number})"
+                if pr_tag not in subject:
+                    subject = f"{subject} {pr_tag}"
+                lines[0] = subject
+                summary = "\n".join(lines)
+
+            commit_msg = ghstack.trailers.interpret_trailers(summary, trailers_to_add)
 
         return DiffMeta(
             elab_diff=elab_diff,

--- a/test/land/default_branch_change.py.test
+++ b/test/land/default_branch_change.py.test
@@ -48,7 +48,7 @@ assert_expected_inline(
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "main"),
     """\
-8927014 Commit A
+47df7ee Commit A (#500)
 dc8bfe4 Initial commit""",
 )
 
@@ -82,16 +82,16 @@ assert_github_state(
 
             This is commit B
 
-            * ab7d5ca Initial 2
+            * d8c62d3 Initial 2
 
         Repository state:
 
-            * ab7d5ca (gh/ezyang/2/head)
+            * d8c62d3 (gh/ezyang/2/head)
             |    Initial 2
-            * 742ae0b (gh/ezyang/2/base)
+            * 66b4cd5 (gh/ezyang/2/base)
             |    Initial 2 (base update)
-            * 8927014 (main, gh/ezyang/1/orig)
-            |    Commit A
+            * 47df7ee (main, gh/ezyang/1/orig)
+            |    Commit A (#500)
             | * 36fcfdf (gh/ezyang/1/head)
             | |    Initial 1
             | * 5a32949 (gh/ezyang/1/base)
@@ -107,13 +107,13 @@ gh_land(diff2.pr_url)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-6b7e56e Commit B (#501)
-1132c50 Commit A (#500)
+c9d09d0 Commit B (#501)
+fd22a9f Commit A (#500)
 dc8bfe4 Initial commit""",
 )
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "main"),
     """\
-8927014 Commit A
+47df7ee Commit A (#500)
 dc8bfe4 Initial commit""",
 )

--- a/test/land/ff.py.test
+++ b/test/land/ff.py.test
@@ -11,7 +11,7 @@ gh_land(pr_url)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-d518c9f Commit A (#500)
+47df7ee Commit A (#500)
 dc8bfe4 Initial commit""",
 )
 

--- a/test/land/ff_stack.py.test
+++ b/test/land/ff_stack.py.test
@@ -16,7 +16,7 @@ gh_land(pr_url)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-4099517 Commit B (#501)
-c28edd5 Commit A (#500)
+87b6210 Commit B (#501)
+9704af8 Commit A (#500)
 dc8bfe4 Initial commit""",
 )

--- a/test/land/ff_stack_two_phase.py.test
+++ b/test/land/ff_stack_two_phase.py.test
@@ -18,7 +18,7 @@ gh_land(pr_url2)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-4099517 Commit B (#501)
-c28edd5 Commit A (#500)
+87b6210 Commit B (#501)
+9704af8 Commit A (#500)
 dc8bfe4 Initial commit""",
 )

--- a/test/land/invalid_resubmit.py.test
+++ b/test/land/invalid_resubmit.py.test
@@ -37,22 +37,22 @@ else:
 
               (omitted)
 
-        [O] #501 Commit A (gh/ezyang/1/head -> gh/ezyang/1/base)
+        [O] #501 Commit A (#500) (gh/ezyang/1/head -> gh/ezyang/1/base)
 
             Stack:
             * __->__ #501
 
             This is commit A
 
-            * d1c3c7e New PR
+            * 5f15948 New PR
 
         Repository state:
 
-            * d1c3c7e (gh/ezyang/1/head)
+            * 5f15948 (gh/ezyang/1/head)
             |    New PR
-            * 5f392f5 (gh/ezyang/1/base)
+            * e54a43e (gh/ezyang/1/base)
             |    New PR (base update)
-            * d518c9f (HEAD -> master)
+            * 47df7ee (HEAD -> master)
             |    Commit A (#500)
             * dc8bfe4
                  Initial commit

--- a/test/land/non_ff.py.test
+++ b/test/land/non_ff.py.test
@@ -17,7 +17,7 @@ gh_land(pr_url)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-8b61aeb Commit A (#500)
+16b6f13 Commit A (#500)
 38808c0 Commit U
 dc8bfe4 Initial commit""",
 )

--- a/test/land/non_ff_stack_two_phase.py.test
+++ b/test/land/non_ff_stack_two_phase.py.test
@@ -22,8 +22,8 @@ gh_land(pr_url2)
 assert_expected_inline(
     get_upstream_sh().git("log", "--oneline", "master"),
     """\
-402e96c Commit B (#501)
-e388a10 Commit A (#500)
+964e411 Commit B (#501)
+e291f44 Commit A (#500)
 a8ca27f Commit C
 dc8bfe4 Initial commit""",
 )

--- a/test/land/update_after_land.py.test
+++ b/test/land/update_after_land.py.test
@@ -55,16 +55,16 @@ else:
 
             This is commit B
 
-            * 87c9ccd Run 3
+            * ba208a5 Run 3
             * 16e1e12 Initial 1
 
         Repository state:
 
-            *   87c9ccd (gh/ezyang/2/head)
+            *   ba208a5 (gh/ezyang/2/head)
             |\\     Run 3
-            | *   a800ca6 (gh/ezyang/2/base)
+            | *   0d1bf0c (gh/ezyang/2/base)
             | |\\     Run 3 (base update)
-            | | * 70eb094 (HEAD -> master)
+            | | * ae7fbca (HEAD -> master)
             | | |    Commit A (#500)
             | | * 7f0288c
             | | |    Commit U

--- a/test/submit/do_not_revert_local_commit_msg_on_skip.py.test
+++ b/test/submit/do_not_revert_local_commit_msg_on_skip.py.test
@@ -11,7 +11,7 @@ if is_direct():
     assert_expected_inline(
         textwrap.indent(git("show", "-s", "--pretty=%B", "HEAD"), " " * 8),
         """\
-        Commit ARGLE
+        Commit ARGLE (#500)
 
         This is commit ARGLE
 
@@ -23,7 +23,7 @@ else:
     assert_expected_inline(
         textwrap.indent(git("show", "-s", "--pretty=%B", "HEAD"), " " * 8),
         """\
-        Commit ARGLE
+        Commit ARGLE (#500)
 
         This is commit ARGLE
 

--- a/test/submit/strip_mentions.py.test
+++ b/test/submit/strip_mentions.py.test
@@ -39,7 +39,7 @@ if is_direct():
             git("log", "--format=%B", "-n1", "origin/gh/ezyang/1/orig"), " " * 8
         ),
         """\
-        Commit 1
+        Commit 1 (#500)
 
         This is my first commit, hello foobar Ivan
 
@@ -54,7 +54,7 @@ else:
             git("log", "--format=%B", "-n1", "origin/gh/ezyang/1/orig"), " " * 8
         ),
         """\
-        Commit 1
+        Commit 1 (#500)
 
         This is my first commit, hello foobar Ivan
 

--- a/test/submit/update_fields.py.test
+++ b/test/submit/update_fields.py.test
@@ -58,7 +58,7 @@ gh_submit("Update 1", update_fields=True)
 if is_direct():
     assert_github_state(
         """\
-        [O] #500 Commit 1 (gh/ezyang/1/head -> master)
+        [O] #500 Commit 1 (#500) (gh/ezyang/1/head -> master)
 
             Original message
 
@@ -75,7 +75,7 @@ if is_direct():
 else:
     assert_github_state(
         """\
-        [O] #500 Commit 1 (gh/ezyang/1/head -> gh/ezyang/1/base)
+        [O] #500 Commit 1 (#500) (gh/ezyang/1/head -> gh/ezyang/1/base)
 
             Stack:
             * __->__ #500

--- a/test/submit/update_fields_preserve_differential_revision.py.test
+++ b/test/submit/update_fields_preserve_differential_revision.py.test
@@ -68,7 +68,7 @@ gh_submit("Update 1", update_fields=True)
 if is_direct():
     assert_github_state(
         """\
-        [O] #500 Commit A (gh/ezyang/1/head -> master)
+        [O] #500 Commit A (#500) (gh/ezyang/1/head -> master)
 
             This is commit A
 
@@ -87,7 +87,7 @@ if is_direct():
 else:
     assert_github_state(
         """\
-        [O] #500 Commit A (gh/ezyang/1/head -> gh/ezyang/1/base)
+        [O] #500 Commit A (#500) (gh/ezyang/1/head -> gh/ezyang/1/base)
 
             Stack:
             * __->__ #500

--- a/test/submit/update_fields_preserves_commit_message.py.test
+++ b/test/submit/update_fields_preserves_commit_message.py.test
@@ -13,7 +13,7 @@ git("commit", "--amend", "-m", "Amended " + A.commit_msg)
 if is_direct():
     assert_github_state(
         """\
-        [O] #500 Amended Commit A (gh/ezyang/1/head -> master)
+        [O] #500 Amended Commit A (#500) (gh/ezyang/1/head -> master)
 
             This is commit A
 
@@ -30,7 +30,7 @@ if is_direct():
 else:
     assert_github_state(
         """\
-        [O] #500 Amended Commit A (gh/ezyang/1/head -> gh/ezyang/1/base)
+        [O] #500 Amended Commit A (#500) (gh/ezyang/1/head -> gh/ezyang/1/base)
 
             Stack:
             * __->__ #500

--- a/test/unlink/basic.py.test
+++ b/test/unlink/basic.py.test
@@ -26,7 +26,7 @@ if is_direct():
 
             * 30b9f2a Initial 1
 
-        [O] #502 Commit A (gh/ezyang/3/head -> master)
+        [O] #502 Commit A (#500) (gh/ezyang/3/head -> master)
 
             This is commit A
 
@@ -35,7 +35,7 @@ if is_direct():
 
             * 2193fd2 Initial 2
 
-        [O] #503 Commit B (gh/ezyang/4/head -> gh/ezyang/3/head)
+        [O] #503 Commit B (#501) (gh/ezyang/4/head -> gh/ezyang/3/head)
 
             This is commit B
 
@@ -81,7 +81,7 @@ else:
 
             * 16e1e12 Initial 1
 
-        [O] #502 Commit A (gh/ezyang/3/head -> gh/ezyang/3/base)
+        [O] #502 Commit A (#500) (gh/ezyang/3/head -> gh/ezyang/3/base)
 
             Stack:
             * #503
@@ -91,7 +91,7 @@ else:
 
             * 12d35d5 Initial 2
 
-        [O] #503 Commit B (gh/ezyang/4/head -> gh/ezyang/4/base)
+        [O] #503 Commit B (#501) (gh/ezyang/4/head -> gh/ezyang/4/base)
 
             Stack:
             * __->__ #503


### PR DESCRIPTION
Fixed #314 by moving the PR number addition to PR opening time, not merge

note that this behaviour is cleaner from a ghstack perspective but doesn't match github behaviour which adds the PR number at merge time.