### PR TITLE
Add tests for merge rules validation engine

### DIFF
--- a/src/ghstack/test_prelude.py
+++ b/src/ghstack/test_prelude.py
@@ -452,7 +452,8 @@ def set_pr_check_runs(
     repo = github.state.repository("pytorch", "pytorch")
     pr = github.state.pull_request(repo, ghstack.github_fake.GitHubNumber(pr_number))
     pr.check_runs = [
-        ghstack.github_fake.CheckRun(name=n, status=s, conclusion=c) for n, s, c in checks
+        ghstack.github_fake.CheckRun(name=n, status=s, conclusion=c)
+        for n, s, c in checks
     ]
 
 

--- a/src/ghstack/test_prelude.py
+++ b/src/ghstack/test_prelude.py
@@ -53,6 +53,9 @@ __all__ = [
     "get_github",
     "get_pr_reviewers",
     "get_pr_labels",
+    "set_pr_files",
+    "set_pr_reviews",
+    "set_pr_check_runs",
     "tick",
     "captured_output",
 ]
@@ -225,7 +228,14 @@ def gh_submit(
     return r
 
 
-def gh_land(pull_request: str) -> None:
+def gh_land(
+    pull_request: str,
+    *,
+    validate_rules: bool = False,
+    dry_run: bool = False,
+    comment_on_failure: bool = False,
+    rules_file: Optional[str] = None,
+) -> None:
     self = CTX
     return ghstack.land.main(
         remote_name="origin",
@@ -233,6 +243,10 @@ def gh_land(pull_request: str) -> None:
         github=self.github,
         sh=self.sh,
         github_url="github.com",
+        validate_rules=validate_rules,
+        dry_run=dry_run,
+        comment_on_failure=comment_on_failure,
+        rules_file=rules_file,
     )
 
 
@@ -410,6 +424,36 @@ def get_pr_labels(pr_number: int) -> List[str]:
     repo = github.state.repository("pytorch", "pytorch")
     pr = github.state.pull_request(repo, ghstack.github_fake.GitHubNumber(pr_number))
     return pr.labels
+
+
+def set_pr_files(pr_number: int, files: List[str]) -> None:
+    """Set the list of changed files for a PR."""
+    github = get_github()
+    repo = github.state.repository("pytorch", "pytorch")
+    pr = github.state.pull_request(repo, ghstack.github_fake.GitHubNumber(pr_number))
+    pr.files = files
+
+
+def set_pr_reviews(pr_number: int, reviews: List[Tuple[str, str]]) -> None:
+    """Set reviews for a PR. reviews is list of (user, state) tuples."""
+    github = get_github()
+    repo = github.state.repository("pytorch", "pytorch")
+    pr = github.state.pull_request(repo, ghstack.github_fake.GitHubNumber(pr_number))
+    pr.reviews = [
+        ghstack.github_fake.PullRequestReview(user=u, state=s) for u, s in reviews
+    ]
+
+
+def set_pr_check_runs(
+    pr_number: int, checks: List[Tuple[str, str, Optional[str]]]
+) -> None:
+    """Set check runs for a PR. checks is list of (name, status, conclusion) tuples."""
+    github = get_github()
+    repo = github.state.repository("pytorch", "pytorch")
+    pr = github.state.pull_request(repo, ghstack.github_fake.GitHubNumber(pr_number))
+    pr.check_runs = [
+        ghstack.github_fake.CheckRun(name=n, status=s, conclusion=c) for n, s, c in checks
+    ]
 
 
 def assert_eq(a: Any, b: Any) -> None:

--- a/test/land/dry_run.py.test
+++ b/test/land/dry_run.py.test
@@ -2,7 +2,8 @@ from ghstack.test_prelude import *
 
 import os
 import tempfile
-from ghstack.github_fake import GitHubNumber, PullRequestReview, CheckRun
+
+from ghstack.github_fake import CheckRun, GitHubNumber, PullRequestReview
 
 init_test()
 commit("A")

--- a/test/land/dry_run.py.test
+++ b/test/land/dry_run.py.test
@@ -2,7 +2,6 @@ from ghstack.test_prelude import *
 
 import os
 import tempfile
-import ghstack.merge_rules
 from ghstack.github_fake import GitHubNumber, PullRequestReview, CheckRun
 
 init_test()
@@ -33,14 +32,14 @@ with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
 try:
     # Get the initial state of master
     initial_log = get_upstream_sh().git("log", "--oneline", "master")
-    
+
     # Dry run should NOT land the commit
     gh_land(pr_url, validate_rules=True, dry_run=True, rules_file=rules_file)
-    
+
     # Verify master is unchanged (no commit was landed)
     final_log = get_upstream_sh().git("log", "--oneline", "master")
     assert_eq(initial_log, final_log)
-    
+
     # The PR should still be open
     assert_eq(pr.closed, False)
 finally:

--- a/test/land/dry_run.py.test
+++ b/test/land/dry_run.py.test
@@ -1,0 +1,49 @@
+from ghstack.test_prelude import *
+
+import os
+import tempfile
+import ghstack.merge_rules
+from ghstack.github_fake import GitHubNumber, PullRequestReview, CheckRun
+
+init_test()
+commit("A")
+(diff,) = gh_submit("Initial 1")
+pr_url = diff.pr_url
+
+# Set up PR with files, approvals, and passing checks
+github = get_github()
+repo = github.state.repository("pytorch", "pytorch")
+pr = github.state.pull_request(repo, GitHubNumber(500))
+pr.files = ["src/core/module.py"]
+pr.reviews = [PullRequestReview(user="maintainer1", state="APPROVED")]
+pr.check_runs = [CheckRun(name="CI", status="completed", conclusion="success")]
+
+# Create a temporary rules file
+rules_content = """
+- name: core-changes
+  patterns: ["src/core/*"]
+  approved_by: ["maintainer1"]
+  mandatory_checks_name: ["CI"]
+"""
+
+with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+    f.write(rules_content)
+    rules_file = f.name
+
+try:
+    # Get the initial state of master
+    initial_log = get_upstream_sh().git("log", "--oneline", "master")
+    
+    # Dry run should NOT land the commit
+    gh_land(pr_url, validate_rules=True, dry_run=True, rules_file=rules_file)
+    
+    # Verify master is unchanged (no commit was landed)
+    final_log = get_upstream_sh().git("log", "--oneline", "master")
+    assert_eq(initial_log, final_log)
+    
+    # The PR should still be open
+    assert_eq(pr.closed, False)
+finally:
+    os.unlink(rules_file)
+
+ok()

--- a/test/land/validate_rules_fail.py.test
+++ b/test/land/validate_rules_fail.py.test
@@ -2,6 +2,7 @@ from ghstack.test_prelude import *
 
 import os
 import tempfile
+
 import ghstack.merge_rules
 from ghstack.github_fake import GitHubNumber
 

--- a/test/land/validate_rules_fail.py.test
+++ b/test/land/validate_rules_fail.py.test
@@ -1,0 +1,46 @@
+from ghstack.test_prelude import *
+
+import os
+import tempfile
+import ghstack.merge_rules
+from ghstack.github_fake import GitHubNumber
+
+init_test()
+commit("A")
+(diff,) = gh_submit("Initial 1")
+pr_url = diff.pr_url
+
+# Set up PR with files but no approvals
+github = get_github()
+repo = github.state.repository("pytorch", "pytorch")
+pr = github.state.pull_request(repo, GitHubNumber(500))
+pr.files = ["src/core/module.py"]
+pr.reviews = []  # No reviews
+
+# Create a temporary rules file
+rules_content = """
+- name: core-changes
+  patterns: ["src/core/*"]
+  approved_by: ["maintainer1"]
+  mandatory_checks_name: []
+"""
+
+with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+    f.write(rules_content)
+    rules_file = f.name
+
+try:
+    # Attempt to land with validation - should raise MergeValidationError
+    assert_expected_raises_inline(
+        ghstack.merge_rules.MergeValidationError,
+        lambda: gh_land(pr_url, validate_rules=True, rules_file=rules_file),
+        """\
+Merge validation failed for PR #500
+Rule: core-changes
+Errors:
+  - Missing required approval from: maintainer1""",
+    )
+finally:
+    os.unlink(rules_file)
+
+ok()

--- a/test/land/validate_rules_pass.py.test
+++ b/test/land/validate_rules_pass.py.test
@@ -2,7 +2,8 @@ from ghstack.test_prelude import *
 
 import os
 import tempfile
-from ghstack.github_fake import GitHubNumber, PullRequestReview, CheckRun
+
+from ghstack.github_fake import CheckRun, GitHubNumber, PullRequestReview
 
 init_test()
 commit("A")

--- a/test/land/validate_rules_pass.py.test
+++ b/test/land/validate_rules_pass.py.test
@@ -1,0 +1,47 @@
+from ghstack.test_prelude import *
+
+import os
+import tempfile
+import ghstack.merge_rules
+from ghstack.github_fake import GitHubNumber, PullRequestReview, CheckRun
+
+init_test()
+commit("A")
+(diff,) = gh_submit("Initial 1")
+pr_url = diff.pr_url
+
+# Set up PR with files, approvals, and passing checks
+github = get_github()
+repo = github.state.repository("pytorch", "pytorch")
+pr = github.state.pull_request(repo, GitHubNumber(500))
+pr.files = ["src/core/module.py"]
+pr.reviews = [PullRequestReview(user="maintainer1", state="APPROVED")]
+pr.check_runs = [CheckRun(name="CI", status="completed", conclusion="success")]
+
+# Create a temporary rules file
+rules_content = """
+- name: core-changes
+  patterns: ["src/core/*"]
+  approved_by: ["maintainer1"]
+  mandatory_checks_name: ["CI"]
+"""
+
+with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+    f.write(rules_content)
+    rules_file = f.name
+
+try:
+    # Land with validation - should succeed
+    gh_land(pr_url, validate_rules=True, rules_file=rules_file)
+    
+    # Verify the commit was landed
+    assert_expected_inline(
+        get_upstream_sh().git("log", "--oneline", "master"),
+        """\
+d518c9f Commit A (#500)
+dc8bfe4 Initial commit""",
+    )
+finally:
+    os.unlink(rules_file)
+
+ok()

--- a/test/land/validate_rules_pass.py.test
+++ b/test/land/validate_rules_pass.py.test
@@ -2,7 +2,6 @@ from ghstack.test_prelude import *
 
 import os
 import tempfile
-import ghstack.merge_rules
 from ghstack.github_fake import GitHubNumber, PullRequestReview, CheckRun
 
 init_test()
@@ -33,7 +32,7 @@ with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
 try:
     # Land with validation - should succeed
     gh_land(pr_url, validate_rules=True, rules_file=rules_file)
-    
+
     # Verify the commit was landed
     assert_expected_inline(
         get_upstream_sh().git("log", "--oneline", "master"),

--- a/test/merge_rules/approval_validation.py.test
+++ b/test/merge_rules/approval_validation.py.test
@@ -1,7 +1,7 @@
 from ghstack.test_prelude import *
 
 import ghstack.merge_rules
-from ghstack.github_fake import PullRequestReview, GitHubNumber
+from ghstack.github_fake import GitHubNumber, PullRequestReview
 
 init_test()
 commit("A")

--- a/test/merge_rules/approval_validation.py.test
+++ b/test/merge_rules/approval_validation.py.test
@@ -1,0 +1,93 @@
+from ghstack.test_prelude import *
+
+import ghstack.merge_rules
+from ghstack.github_fake import PullRequestReview, GitHubNumber
+
+init_test()
+commit("A")
+(A,) = gh_submit("Initial 1")
+
+# Set up PR with files and NO approval
+github = get_github()
+repo = github.state.repository("pytorch", "pytorch")
+pr = github.state.pull_request(repo, GitHubNumber(500))
+pr.files = ["src/core/module.py"]
+pr.reviews = []  # No reviews yet
+
+rules = [
+    ghstack.merge_rules.MergeRule(
+        name="core",
+        patterns=["src/core/*"],
+        approved_by=["maintainer1"],
+        mandatory_checks_name=[],
+    )
+]
+
+validator = ghstack.merge_rules.MergeValidator(github, "pytorch", "pytorch")
+result = validator.validate_pr(500, rules)
+
+# Should fail - missing approval
+assert_eq(result.valid, False)
+assert "Missing required approval" in result.errors[0]
+
+# Add approval from wrong user - should still fail
+pr.reviews = [PullRequestReview(user="random_user", state="APPROVED")]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, False)
+
+# Add approval from required user - should pass
+pr.reviews = [PullRequestReview(user="maintainer1", state="APPROVED")]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, True)
+
+# Test multiple required approvers - any one should work
+rules = [
+    ghstack.merge_rules.MergeRule(
+        name="core",
+        patterns=["src/core/*"],
+        approved_by=["maintainer1", "maintainer2"],
+        mandatory_checks_name=[],
+    )
+]
+
+pr.reviews = [PullRequestReview(user="maintainer2", state="APPROVED")]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, True)
+
+# Test that CHANGES_REQUESTED doesn't count as approval
+pr.reviews = [PullRequestReview(user="maintainer1", state="CHANGES_REQUESTED")]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, False)
+
+# Test that latest review state wins
+pr.reviews = [
+    PullRequestReview(user="maintainer1", state="APPROVED"),
+    PullRequestReview(user="maintainer1", state="CHANGES_REQUESTED"),
+]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, False)
+
+# Re-approval after changes_requested should work
+pr.reviews = [
+    PullRequestReview(user="maintainer1", state="CHANGES_REQUESTED"),
+    PullRequestReview(user="maintainer1", state="APPROVED"),
+]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, True)
+
+# Test "any" special approver - any approval should work
+rules = [
+    ghstack.merge_rules.MergeRule(
+        name="any-approval",
+        patterns=["src/*"],
+        approved_by=["any"],
+        mandatory_checks_name=[],
+    )
+]
+
+pr.files = ["src/module.py"]
+pr.reviews = [PullRequestReview(user="anyone", state="APPROVED")]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, True)
+
+ok()

--- a/test/merge_rules/check_validation.py.test
+++ b/test/merge_rules/check_validation.py.test
@@ -1,0 +1,91 @@
+from ghstack.test_prelude import *
+
+import ghstack.merge_rules
+from ghstack.github_fake import CheckRun, GitHubNumber
+
+init_test()
+commit("A")
+(A,) = gh_submit("Initial 1")
+
+github = get_github()
+repo = github.state.repository("pytorch", "pytorch")
+pr = github.state.pull_request(repo, GitHubNumber(500))
+pr.files = ["src/module.py"]
+
+rules = [
+    ghstack.merge_rules.MergeRule(
+        name="ci-required",
+        patterns=["src/*"],
+        approved_by=["any"],
+        mandatory_checks_name=["CI", "lint"],
+    )
+]
+
+validator = ghstack.merge_rules.MergeValidator(github, "pytorch", "pytorch")
+
+# Test missing checks - should fail
+pr.check_runs = []
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, False)
+assert 'Check "CI" has not run' in result.errors[0]
+
+# Test only one check present - should fail
+pr.check_runs = [
+    CheckRun(name="CI", status="completed", conclusion="success"),
+]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, False)
+assert 'Check "lint" has not run' in result.errors[0]
+
+# Test failed check - should fail
+pr.check_runs = [
+    CheckRun(name="CI", status="completed", conclusion="failure"),
+    CheckRun(name="lint", status="completed", conclusion="success"),
+]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, False)
+assert 'Check "CI" has not passed' in result.errors[0]
+
+# Test in_progress check - should fail
+pr.check_runs = [
+    CheckRun(name="CI", status="in_progress", conclusion=None),
+    CheckRun(name="lint", status="completed", conclusion="success"),
+]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, False)
+assert 'Check "CI" has not completed' in result.errors[0]
+
+# Test queued check - should fail
+pr.check_runs = [
+    CheckRun(name="CI", status="queued", conclusion=None),
+    CheckRun(name="lint", status="completed", conclusion="success"),
+]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, False)
+assert 'Check "CI" has not completed' in result.errors[0]
+
+# Test passing checks - should pass
+pr.check_runs = [
+    CheckRun(name="CI", status="completed", conclusion="success"),
+    CheckRun(name="lint", status="completed", conclusion="success"),
+]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, True)
+
+# Test neutral conclusion - should pass (neutral is acceptable)
+pr.check_runs = [
+    CheckRun(name="CI", status="completed", conclusion="neutral"),
+    CheckRun(name="lint", status="completed", conclusion="success"),
+]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, True)
+
+# Test skipped conclusion - should pass
+pr.check_runs = [
+    CheckRun(name="CI", status="completed", conclusion="skipped"),
+    CheckRun(name="lint", status="completed", conclusion="success"),
+]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, True)
+
+ok()

--- a/test/merge_rules/ignore_flaky.py.test
+++ b/test/merge_rules/ignore_flaky.py.test
@@ -1,0 +1,61 @@
+from ghstack.test_prelude import *
+
+import ghstack.merge_rules
+from ghstack.github_fake import CheckRun, GitHubNumber
+
+init_test()
+commit("A")
+(A,) = gh_submit("Initial 1")
+
+github = get_github()
+repo = github.state.repository("pytorch", "pytorch")
+pr = github.state.pull_request(repo, GitHubNumber(500))
+pr.files = ["src/module.py"]
+pr.check_runs = [CheckRun(name="flaky-test", status="completed", conclusion="failure")]
+
+# Without ignore_flaky_failures - should fail
+rules = [
+    ghstack.merge_rules.MergeRule(
+        name="test",
+        patterns=["src/*"],
+        approved_by=["any"],
+        mandatory_checks_name=["flaky-test"],
+        ignore_flaky_failures=False,
+    )
+]
+validator = ghstack.merge_rules.MergeValidator(github, "pytorch", "pytorch")
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, False)
+assert 'Check "flaky-test" has not passed' in result.errors[0]
+
+# With ignore_flaky_failures - should pass despite failure
+rules = [
+    ghstack.merge_rules.MergeRule(
+        name="test",
+        patterns=["src/*"],
+        approved_by=["any"],
+        mandatory_checks_name=["flaky-test"],
+        ignore_flaky_failures=True,
+    )
+]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, True)
+
+# ignore_flaky_failures should NOT ignore missing checks
+pr.check_runs = []
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, False)
+assert 'Check "flaky-test" has not run' in result.errors[0]
+
+# ignore_flaky_failures should NOT ignore in_progress checks
+pr.check_runs = [CheckRun(name="flaky-test", status="in_progress", conclusion=None)]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, False)
+assert 'Check "flaky-test" has not completed' in result.errors[0]
+
+# Success should still pass with ignore_flaky_failures
+pr.check_runs = [CheckRun(name="flaky-test", status="completed", conclusion="success")]
+result = validator.validate_pr(500, rules)
+assert_eq(result.valid, True)
+
+ok()

--- a/test/merge_rules/pattern_matching.py.test
+++ b/test/merge_rules/pattern_matching.py.test
@@ -1,0 +1,82 @@
+from ghstack.test_prelude import *
+
+import ghstack.merge_rules
+
+init_test()
+
+# Create test rules with different patterns
+rules = [
+    ghstack.merge_rules.MergeRule(
+        name="core",
+        patterns=["src/core/*"],
+        approved_by=[],
+        mandatory_checks_name=[],
+    ),
+    ghstack.merge_rules.MergeRule(
+        name="tests",
+        patterns=["test/*.py", "test/**/*.py"],
+        approved_by=[],
+        mandatory_checks_name=[],
+    ),
+    ghstack.merge_rules.MergeRule(
+        name="docs",
+        patterns=["*.md", "docs/*"],
+        approved_by=[],
+        mandatory_checks_name=[],
+    ),
+]
+
+validator = ghstack.merge_rules.MergeValidator(get_github(), "pytorch", "pytorch")
+
+# Test exact match on first rule
+rule = validator.find_matching_rule(["src/core/module.py"], rules)
+assert_eq(rule.name, "core")
+
+# Test match on second rule
+rule = validator.find_matching_rule(["test/unit_test.py"], rules)
+assert_eq(rule.name, "tests")
+
+# Test nested test file
+rule = validator.find_matching_rule(["test/integration/test_api.py"], rules)
+assert_eq(rule.name, "tests")
+
+# Test docs rule with markdown
+rule = validator.find_matching_rule(["README.md"], rules)
+assert_eq(rule.name, "docs")
+
+# Test no match returns None
+rule = validator.find_matching_rule(["some_random_file.txt"], rules)
+assert_eq(rule, None)
+
+# Test first matching rule wins when file matches multiple patterns
+# The file "docs/guide.md" would match both "*.md" (docs) and "docs/*" (docs)
+rule = validator.find_matching_rule(["docs/guide.md"], rules)
+assert_eq(rule.name, "docs")
+
+# Test empty file list returns None
+rule = validator.find_matching_rule([], rules)
+assert_eq(rule, None)
+
+# Test multiple files - first matching file determines the rule
+rule = validator.find_matching_rule(["README.txt", "src/core/main.py"], rules)
+assert_eq(rule.name, "core")
+
+# Test that patterns are checked in order - first rule to match a file wins
+combined_rules = [
+    ghstack.merge_rules.MergeRule(
+        name="specific",
+        patterns=["src/core/special.py"],
+        approved_by=[],
+        mandatory_checks_name=[],
+    ),
+    ghstack.merge_rules.MergeRule(
+        name="general",
+        patterns=["src/core/*"],
+        approved_by=[],
+        mandatory_checks_name=[],
+    ),
+]
+rule = validator.find_matching_rule(["src/core/special.py"], combined_rules)
+assert_eq(rule.name, "specific")
+
+ok()

--- a/test/merge_rules/yaml_parsing.py.test
+++ b/test/merge_rules/yaml_parsing.py.test
@@ -1,0 +1,64 @@
+from ghstack.test_prelude import *
+
+import ghstack.merge_rules
+
+init_test()
+
+# Test basic YAML parsing with all fields
+loader = ghstack.merge_rules.MergeRulesLoader(get_github(), "pytorch", "pytorch")
+rules = loader._parse_yaml(
+    """
+- name: core-changes
+  patterns: ["src/core/*"]
+  approved_by: ["maintainer1", "pytorch/core-team"]
+  mandatory_checks_name: ["CI", "lint"]
+  ignore_flaky_failures: true
+"""
+)
+
+assert_eq(len(rules), 1)
+assert_eq(rules[0].name, "core-changes")
+assert_eq(rules[0].patterns, ["src/core/*"])
+assert_eq(rules[0].approved_by, ["maintainer1", "pytorch/core-team"])
+assert_eq(rules[0].mandatory_checks_name, ["CI", "lint"])
+assert_eq(rules[0].ignore_flaky_failures, True)
+
+# Test parsing multiple rules
+rules = loader._parse_yaml(
+    """
+- name: rule1
+  patterns: ["src/*"]
+  approved_by: ["user1"]
+  mandatory_checks_name: []
+- name: rule2
+  patterns: ["test/*"]
+  approved_by: ["user2"]
+  mandatory_checks_name: ["test-ci"]
+"""
+)
+
+assert_eq(len(rules), 2)
+assert_eq(rules[0].name, "rule1")
+assert_eq(rules[1].name, "rule2")
+assert_eq(rules[1].mandatory_checks_name, ["test-ci"])
+
+# Test default values
+rules = loader._parse_yaml(
+    """
+- name: minimal
+  patterns: ["*.py"]
+"""
+)
+
+assert_eq(len(rules), 1)
+assert_eq(rules[0].name, "minimal")
+assert_eq(rules[0].patterns, ["*.py"])
+assert_eq(rules[0].approved_by, [])
+assert_eq(rules[0].mandatory_checks_name, [])
+assert_eq(rules[0].ignore_flaky_failures, False)
+
+# Test empty rule list
+rules = loader._parse_yaml("[]")
+assert_eq(len(rules), 0)
+
+ok()


### PR DESCRIPTION
Adds comprehensive test coverage for the merge rules feature:

- test/merge_rules/yaml_parsing.py.test: YAML parsing tests
- test/merge_rules/pattern_matching.py.test: fnmatch pattern tests
- test/merge_rules/approval_validation.py.test: approver validation tests
- test/merge_rules/check_validation.py.test: CI check validation tests
- test/merge_rules/ignore_flaky.py.test: ignore_flaky_failures flag tests

Adds land command integration tests:
- test/land/validate_rules_fail.py.test: validation blocks land
- test/land/validate_rules_pass.py.test: validation passes and lands
- test/land/dry_run.py.test: dry run mode validates but doesn't land

Also adds helper functions to test_prelude.py:
- set_pr_files, set_pr_reviews, set_pr_check_runs
- Updated gh_land to support validate_rules, dry_run, comment_on_failure flags

Co-authored-by: Cursor <cursoragent@cursor.com>