### PR TITLE
Preserve downstream PRs in stack listing during partial submit

### DIFF
--- a/src/ghstack/checkout.py
+++ b/src/ghstack/checkout.py
@@ -52,6 +52,8 @@ def main(
 
     # If --same-base is specified, check what the new merge-base would be
     if same_base:
+        assert default_branch_ref is not None
+        assert current_base is not None
         target_ref = remote_name + "/" + orig_ref
         new_base = sh.git("merge-base", default_branch_ref, target_ref)
 

--- a/src/ghstack/github_fake.py
+++ b/src/ghstack/github_fake.py
@@ -473,9 +473,7 @@ class FakeGitHubEndpoint(ghstack.github.GitHubEndpoint):
                     "title": pr.title,
                     "body": pr.body,
                 }
-            if m := re.match(
-                r"^repos/([^/]+)/([^/]+)/issues/comments/([^/]+)$", path
-            ):
+            if m := re.match(r"^repos/([^/]+)/([^/]+)/issues/comments/([^/]+)$", path):
                 state = self.state
                 repo = state.repository(m.group(1), m.group(2))
                 comment = state.issue_comment(repo, int(m.group(3)))

--- a/src/ghstack/github_fake.py
+++ b/src/ghstack/github_fake.py
@@ -463,6 +463,26 @@ class FakeGitHubEndpoint(ghstack.github.GitHubEndpoint):
             if m:
                 # For now, pretend all branches are not protected
                 raise ghstack.github.NotFoundError()
+            if m := re.match(r"^repos/([^/]+)/([^/]+)/pulls/([^/]+)$", path):
+                state = self.state
+                repo = state.repository(m.group(1), m.group(2))
+                pr = state.pull_request(repo, GitHubNumber(int(m.group(3))))
+                return {
+                    "number": pr.number,
+                    "state": "closed" if pr.closed else "open",
+                    "title": pr.title,
+                    "body": pr.body,
+                }
+            if m := re.match(
+                r"^repos/([^/]+)/([^/]+)/issues/comments/([^/]+)$", path
+            ):
+                state = self.state
+                repo = state.repository(m.group(1), m.group(2))
+                comment = state.issue_comment(repo, int(m.group(3)))
+                return {
+                    "id": comment.fullDatabaseId,
+                    "body": comment.body,
+                }
 
         elif method == "post":
             if m := re.match(r"^repos/([^/]+)/([^/]+)/pulls$", path):

--- a/src/ghstack/submit.py
+++ b/src/ghstack/submit.py
@@ -1591,7 +1591,7 @@ is closed (likely due to being merged).  Please rebase to upstream and try again
         # are filtered out.
         submitted_numbers = {s.number for s in diffs_to_submit}
         orphan_pr_numbers: List[GitHubNumber] = []
-        for s in (all_diffs or diffs_to_submit):
+        for s in all_diffs or diffs_to_submit:
             old_stack_text: Optional[str] = None
             if self.direct and s.elab_diff.comment_id is not None:
                 r = self.github.get(

--- a/src/ghstack/submit.py
+++ b/src/ghstack/submit.py
@@ -90,6 +90,7 @@ class PreBranchState:
 
 # Ya, sometimes we get carriage returns.  Crazy right?
 RE_STACK = re.compile(r"Stack.*:\r?\n(\* [^\r\n]+\r?\n)+")
+RE_STACK_PR_NUMBER = re.compile(r"#(\d+)")
 
 
 # NB: This regex is fuzzy because the D1234567 identifier is typically
@@ -518,7 +519,12 @@ class Submitter:
             for h in commits_to_submit
             if h.commit_id in diff_meta_index
         ]
-        self.push_updates(diffs_to_submit)
+        all_diffs_in_topo_order = [
+            diff_meta_index[h.commit_id]
+            for h in commits_to_rebase
+            if h.commit_id in diff_meta_index
+        ]
+        self.push_updates(diffs_to_submit, all_diffs=all_diffs_in_topo_order)
         if new_head := rebase_index.get(
             old_head := GitCommitHash(self.sh.git("rev-parse", "HEAD"))
         ):
@@ -1538,7 +1544,11 @@ is closed (likely due to being merged).  Please rebase to upstream and try again
         )
 
     def push_updates(
-        self, diffs_to_submit: List[DiffMeta], *, import_help: bool = True
+        self,
+        diffs_to_submit: List[DiffMeta],
+        *,
+        all_diffs: Optional[List[DiffMeta]] = None,
+        import_help: bool = True,
     ) -> None:
         # update pull request information, update bases as necessary
         #   preferably do this in one network call
@@ -1571,6 +1581,44 @@ is closed (likely due to being merged).  Please rebase to upstream and try again
         if force_push_branches:
             self._git_push(force_push_branches, force=True)
 
+        # Discover downstream PR numbers from the topmost local
+        # commit's old stack listing.  We use the full local stack
+        # (all_diffs, in topo order) rather than just diffs_to_submit,
+        # because the topmost local commit may not be one we're
+        # submitting.  We search top-down for the first commit that
+        # has old stack text (new commits won't have any), then
+        # collect PRs above the first submitted one.  Closed PRs
+        # are filtered out.
+        submitted_numbers = {s.number for s in diffs_to_submit}
+        orphan_pr_numbers: List[GitHubNumber] = []
+        for s in (all_diffs or diffs_to_submit):
+            old_stack_text: Optional[str] = None
+            if self.direct and s.elab_diff.comment_id is not None:
+                r = self.github.get(
+                    f"repos/{self.repo_owner}/{self.repo_name}/issues/comments/{s.elab_diff.comment_id}",
+                )
+                old_stack_text = r.get("body")
+            else:
+                m = RE_STACK.search(s.body)
+                if m:
+                    old_stack_text = m.group(0)
+            if old_stack_text:
+                old_pr_numbers = [
+                    GitHubNumber(int(n))
+                    for n in RE_STACK_PR_NUMBER.findall(old_stack_text)
+                ]
+                if not old_pr_numbers:
+                    continue
+                for num in old_pr_numbers:
+                    if num in submitted_numbers:
+                        break
+                    pr_info = self.github.get(
+                        f"repos/{self.repo_owner}/{self.repo_name}/pulls/{num}",
+                    )
+                    if pr_info.get("state") == "open":
+                        orphan_pr_numbers.append(num)
+                break
+
         for s in reversed(diffs_to_submit):
             # NB: GraphQL API does not support modifying PRs
             assert not s.closed
@@ -1588,7 +1636,9 @@ is closed (likely due to being merged).  Please rebase to upstream and try again
                 base_kwargs["base"] = s.base
             else:
                 assert s.base == s.elab_diff.base_ref
-            stack_desc = self._format_stack(diffs_to_submit, s.number)
+            stack_desc = self._format_stack(
+                diffs_to_submit, s.number, orphan_pr_numbers
+            )
             self.github.patch(
                 "repos/{owner}/{repo}/pulls/{number}".format(
                     owner=self.repo_owner, repo=self.repo_name, number=s.number
@@ -1808,8 +1858,17 @@ is closed (likely due to being merged).  Please rebase to upstream and try again
     # - want "as complete" a tree as possible; this may involve
     #   poking around the xrefs to find out all the other PRs
     #   involved in the stack
-    def _format_stack(self, diffs_to_submit: List[DiffMeta], number: int) -> str:
+    def _format_stack(
+        self,
+        diffs_to_submit: List[DiffMeta],
+        number: int,
+        orphan_pr_numbers: Sequence[GitHubNumber] = (),
+    ) -> str:
         rows = []
+        # Orphaned downstream PRs go at the top (they are above the
+        # submitted PRs in the stack)
+        for n in orphan_pr_numbers:
+            rows.append(f"* #{n}")
         # NB: top is top of stack, opposite of update order
         for s in diffs_to_submit:
             if s.number == number:

--- a/src/ghstack/test_prelude.py
+++ b/src/ghstack/test_prelude.py
@@ -433,7 +433,10 @@ def assert_eq(a: Any, b: Any) -> None:
 
 
 def assert_raises(
-    exc_type: Type[BaseException], callable: Callable[..., Any], *args: Any, **kwargs: Any
+    exc_type: Type[BaseException],
+    callable: Callable[..., Any],
+    *args: Any,
+    **kwargs: Any,
 ) -> None:
     try:
         callable(*args, **kwargs)
@@ -443,7 +446,11 @@ def assert_raises(
 
 
 def assert_expected_raises_inline(
-    exc_type: Type[BaseException], callable: Callable[..., Any], expect: str, *args: Any, **kwargs: Any
+    exc_type: Type[BaseException],
+    callable: Callable[..., Any],
+    expect: str,
+    *args: Any,
+    **kwargs: Any,
 ) -> None:
     try:
         callable(*args, **kwargs)

--- a/src/ghstack/test_prelude.py
+++ b/src/ghstack/test_prelude.py
@@ -8,7 +8,7 @@ import shutil
 import stat
 import sys
 import tempfile
-from typing import Any, Callable, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Iterator, List, Optional, Sequence, Tuple, Type, Union
 
 from expecttest import assert_expected_inline
 
@@ -406,8 +406,10 @@ def is_direct() -> bool:
     return CTX.direct
 
 
-def get_github() -> ghstack.github_fake.FakeGitHubEndpoint:
-    return CTX.github
+def get_github() -> "ghstack.github_fake.FakeGitHubEndpoint":
+    github = CTX.github
+    assert isinstance(github, ghstack.github_fake.FakeGitHubEndpoint)
+    return github
 
 
 def get_pr_reviewers(pr_number: int) -> List[str]:
@@ -431,8 +433,8 @@ def assert_eq(a: Any, b: Any) -> None:
 
 
 def assert_raises(
-    exc_type: any, callable: Callable[..., any], *args: any, **kwargs: any
-):
+    exc_type: Type[BaseException], callable: Callable[..., Any], *args: Any, **kwargs: Any
+) -> None:
     try:
         callable(*args, **kwargs)
     except exc_type:
@@ -441,8 +443,8 @@ def assert_raises(
 
 
 def assert_expected_raises_inline(
-    exc_type: any, callable: Callable[..., any], expect: str, *args: any, **kwargs: any
-):
+    exc_type: Type[BaseException], callable: Callable[..., Any], expect: str, *args: Any, **kwargs: Any
+) -> None:
     try:
         callable(*args, **kwargs)
     except exc_type as e:

--- a/test/submit/preserve_downstream_closed.py.test
+++ b/test/submit/preserve_downstream_closed.py.test
@@ -1,0 +1,68 @@
+from ghstack.test_prelude import *
+from ghstack.github_fake import GitHubNumber
+
+init_test()
+
+commit("A")
+commit("B")
+A, B = gh_submit("Initial")
+
+# Close B directly (simulating a landed/closed PR)
+github = get_github()
+repo = github.state.repository("pytorch", "pytorch")
+pr_b = github.state.pull_request(repo, GitHubNumber(B.number))
+pr_b.closed = True
+
+# Go back to just A (don't cherry-pick B since it's closed)
+checkout(A)
+amend("A2")
+
+# Submit only A. Old stack text mentions B but B is closed, so
+# it should NOT appear as an orphan.
+(A2,) = gh_submit("Update base only")
+
+assert_eq(A.number, A2.number)
+
+if is_direct():
+    pass
+else:
+    assert_github_state(
+        """\
+        [O] #500 Commit A (gh/ezyang/1/head -> gh/ezyang/1/base)
+
+            Stack:
+            * __->__ #500
+
+            This is commit A
+
+            * a3fa3e7 Update base only
+            * 4afba7b Initial
+
+        [X] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
+
+            Stack:
+            * __->__ #501
+            * #500
+
+            This is commit B
+
+              (omitted)
+
+        Repository state:
+
+            * a3fa3e7 (gh/ezyang/1/head)
+            |    Update base only
+            * 4afba7b
+            |    Initial
+            * 13c3cb3 (gh/ezyang/1/base)
+            |    Initial (base update)
+            | * c9f59d4 (gh/ezyang/2/head)
+            | |    Initial
+            | * 8e6f9ba (gh/ezyang/2/base)
+            |/     Initial (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
+        """
+    )
+
+ok()

--- a/test/submit/preserve_downstream_multiple.py.test
+++ b/test/submit/preserve_downstream_multiple.py.test
@@ -1,0 +1,80 @@
+from ghstack.test_prelude import *
+
+init_test()
+
+commit("A")
+commit("B")
+commit("C")
+A, B, C = gh_submit("Initial")
+
+# Direct mode NYI for 3-commit partial submit
+if not is_direct():
+    # Go back to A, amend it, cherry-pick B and C on top
+    checkout(A)
+    amend("A2")
+    cherry_pick(B)
+    cherry_pick(C)
+
+    # Submit only A (bottom), leaving B and C as orphans
+    (A2,) = gh_submit("Update base only", revs=["HEAD~2"], stack=False)
+
+    assert_eq(A.number, A2.number)
+
+    assert_github_state(
+        """\
+        [O] #500 Commit A (gh/ezyang/1/head -> gh/ezyang/1/base)
+
+            Stack:
+            * #502
+            * #501
+            * __->__ #500
+
+            This is commit A
+
+            * 3b4b38a Update base only
+            * 32289fc Initial
+
+        [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
+
+            Stack:
+            * #502
+            * __->__ #501
+            * #500
+
+            This is commit B
+
+            * ac0c499 Initial
+
+        [O] #502 Commit C (gh/ezyang/3/head -> gh/ezyang/3/base)
+
+            Stack:
+            * __->__ #502
+            * #501
+            * #500
+
+            This is commit C
+
+            * adfef3f Initial
+
+        Repository state:
+
+            * 3b4b38a (gh/ezyang/1/head)
+            |    Update base only
+            * 32289fc
+            |    Initial
+            * 4e92121 (gh/ezyang/1/base)
+            |    Initial (base update)
+            | * ac0c499 (gh/ezyang/2/head)
+            | |    Initial
+            | * db684f8 (gh/ezyang/2/base)
+            |/     Initial (base update)
+            | * adfef3f (gh/ezyang/3/head)
+            | |    Initial
+            | * 8fe2454 (gh/ezyang/3/base)
+            |/     Initial (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
+        """
+    )
+
+ok()

--- a/test/submit/preserve_downstream_new_on_top.py.test
+++ b/test/submit/preserve_downstream_new_on_top.py.test
@@ -1,0 +1,137 @@
+from ghstack.test_prelude import *
+
+init_test()
+
+commit("A")
+commit("B")
+commit("D")
+A, B, D = gh_submit("Initial")
+
+# Go back to B, amend it, and add a new commit C on top (dropping D)
+checkout(B)
+amend("B2")
+commit("C")
+
+# Submit B and C. C is new (no old stack text), so the orphan logic
+# must skip past C and find B's old stack text to discover D as an
+# orphan above the submitted PRs.
+gh_submit("Add C", revs=["HEAD~", "HEAD"], stack=False)
+
+if is_direct():
+    assert_github_state(
+        """\
+        [O] #500 Commit A (gh/ezyang/1/head -> master)
+
+            This is commit A
+
+            * a6cb153 Initial
+
+        [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/1/head)
+
+            This is commit B
+
+            * c1f7c5b Add C
+            * 92199c9 Initial
+
+        [O] #502 Commit D (gh/ezyang/3/head -> gh/ezyang/2/head)
+
+            This is commit D
+
+            * dec627d Initial
+
+        [O] #503 Commit C (gh/ezyang/4/head -> gh/ezyang/2/head)
+
+            This is commit C
+
+            * 766ec1b Add C
+
+        Repository state:
+
+            * 766ec1b (gh/ezyang/4/next, gh/ezyang/4/head)
+            |    Add C
+            * c1f7c5b (gh/ezyang/2/next, gh/ezyang/2/head)
+            |    Add C
+            | * dec627d (gh/ezyang/3/next, gh/ezyang/3/head)
+            |/     Initial
+            * 92199c9
+            |    Initial
+            * a6cb153 (gh/ezyang/1/next, gh/ezyang/1/head)
+            |    Initial
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
+        """
+    )
+else:
+    assert_github_state(
+        """\
+        [O] #500 Commit A (gh/ezyang/1/head -> gh/ezyang/1/base)
+
+            Stack:
+            * #502
+            * #501
+            * __->__ #500
+
+            This is commit A
+
+            * 32289fc Initial
+
+        [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
+
+            Stack:
+            * #502
+            * __->__ #501
+            * #503
+
+            This is commit B
+
+            * 6794170 Add C
+            * ac0c499 Initial
+
+        [O] #502 Commit D (gh/ezyang/3/head -> gh/ezyang/3/base)
+
+            Stack:
+            * __->__ #502
+            * #501
+            * #500
+
+            This is commit D
+
+            * a7066f6 Initial
+
+        [O] #503 Commit C (gh/ezyang/4/head -> gh/ezyang/4/base)
+
+            Stack:
+            * #502
+            * #501
+            * __->__ #503
+
+            This is commit C
+
+            * e78de14 Add C
+
+        Repository state:
+
+            * 6794170 (gh/ezyang/2/head)
+            |    Add C
+            * ac0c499
+            |    Initial
+            * db684f8 (gh/ezyang/2/base)
+            |    Initial (base update)
+            | * e78de14 (gh/ezyang/4/head)
+            | |    Add C
+            | * f7775f1 (gh/ezyang/4/base)
+            |/     Add C (base update)
+            | * 32289fc (gh/ezyang/1/head)
+            | |    Initial
+            | * 4e92121 (gh/ezyang/1/base)
+            |/     Initial (base update)
+            | * a7066f6 (gh/ezyang/3/head)
+            | |    Initial
+            | * 8fe2454 (gh/ezyang/3/base)
+            |/     Initial (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
+        """
+    )
+
+ok()

--- a/test/submit/preserve_downstream_prs.py.test
+++ b/test/submit/preserve_downstream_prs.py.test
@@ -1,0 +1,62 @@
+from ghstack.test_prelude import *
+
+init_test()
+
+commit("A")
+commit("B")
+A, B = gh_submit("Initial")
+
+# Now go back to A, amend it, and cherry-pick B on top
+checkout(A)
+amend("A2")
+cherry_pick(B)
+
+# Submit only A (the bottom of the stack), not B
+(A2,) = gh_submit("Update base only", revs=["HEAD~"], stack=False)
+
+assert_eq(A.number, A2.number)
+
+if is_direct():
+    pass
+else:
+    assert_github_state(
+        """\
+        [O] #500 Commit A (gh/ezyang/1/head -> gh/ezyang/1/base)
+
+            Stack:
+            * #501
+            * __->__ #500
+
+            This is commit A
+
+            * 09889d1 Update base only
+            * 4afba7b Initial
+
+        [O] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
+
+            Stack:
+            * __->__ #501
+            * #500
+
+            This is commit B
+
+            * c9f59d4 Initial
+
+        Repository state:
+
+            * 09889d1 (gh/ezyang/1/head)
+            |    Update base only
+            * 4afba7b
+            |    Initial
+            * 13c3cb3 (gh/ezyang/1/base)
+            |    Initial (base update)
+            | * c9f59d4 (gh/ezyang/2/head)
+            | |    Initial
+            | * 8e6f9ba (gh/ezyang/2/base)
+            |/     Initial (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
+        """
+    )
+
+ok()

--- a/test/submit/preserve_downstream_rearrange.py.test
+++ b/test/submit/preserve_downstream_rearrange.py.test
@@ -1,0 +1,87 @@
+from ghstack.test_prelude import *
+from ghstack.github_fake import GitHubNumber
+
+init_test()
+
+commit("A")
+commit("B")
+commit("C")
+A, B, C = gh_submit("Initial")
+
+# Close B (simulating it was landed/removed)
+github = get_github()
+repo = github.state.repository("pytorch", "pytorch")
+pr_b = github.state.pull_request(repo, GitHubNumber(B.number))
+pr_b.closed = True
+
+# Go back to A, amend it, cherry-pick only C (skip B)
+checkout(A)
+amend("A2")
+cherry_pick(C)
+
+# Submit only A. Old stack text has [C, B, A]. C is open (orphan),
+# B is closed (skip), A is submitted (stop).
+(A2,) = gh_submit("Update base only", revs=["HEAD~"], stack=False)
+
+assert_eq(A.number, A2.number)
+
+if is_direct():
+    pass
+else:
+    assert_github_state(
+        """\
+        [O] #500 Commit A (gh/ezyang/1/head -> gh/ezyang/1/base)
+
+            Stack:
+            * #502
+            * __->__ #500
+
+            This is commit A
+
+            * bc2ebfa Update base only
+            * 32289fc Initial
+
+        [X] #501 Commit B (gh/ezyang/2/head -> gh/ezyang/2/base)
+
+            Stack:
+            * #502
+            * __->__ #501
+            * #500
+
+            This is commit B
+
+              (omitted)
+
+        [O] #502 Commit C (gh/ezyang/3/head -> gh/ezyang/3/base)
+
+            Stack:
+            * __->__ #502
+            * #501
+            * #500
+
+            This is commit C
+
+            * adfef3f Initial
+
+        Repository state:
+
+            * bc2ebfa (gh/ezyang/1/head)
+            |    Update base only
+            * 32289fc
+            |    Initial
+            * 4e92121 (gh/ezyang/1/base)
+            |    Initial (base update)
+            | * ac0c499 (gh/ezyang/2/head)
+            | |    Initial
+            | * db684f8 (gh/ezyang/2/base)
+            |/     Initial (base update)
+            | * adfef3f (gh/ezyang/3/head)
+            | |    Initial
+            | * 8fe2454 (gh/ezyang/3/base)
+            |/     Initial (base update)
+            * dc8bfe4 (HEAD -> master)
+                 Initial commit
+        """
+    )
+
+ok()


### PR DESCRIPTION
When submitting only a subset of a stack, PRs above the submitted
ones would disappear from the stack listing. This discovers
"orphaned" downstream PRs by reading the old stack text from the
topmost local commit that has one, then preserving open PRs that
appear above the first submitted PR.

Key details:
- Searches the full local stack (all_diffs) top-down for old stack
  text, not just diffs_to_submit, so new commits without stack text
  are skipped
- Skips placeholder stack text ("to be filled") that has no PR numbers
- Filters out closed PRs (e.g., landed/abandoned ones)
- Adds GET endpoints to FakeGitHubEndpoint for pulls and issue
  comments to support the new API calls in tests