### PR TITLE
Strip ghstack-comment-id trailer and trailing newlines during unlink

### DIFF
--- a/src/ghstack/unlink.py
+++ b/src/ghstack/unlink.py
@@ -14,6 +14,7 @@ import ghstack.shell
 from ghstack.types import GitCommitHash
 
 RE_GHSTACK_SOURCE_ID = re.compile(r"^ghstack-source-id: (.+)\n?", re.MULTILINE)
+RE_GHSTACK_COMMENT_ID = re.compile(r"^ghstack-comment-id: (.+)\n?", re.MULTILINE)
 
 
 def main(
@@ -93,12 +94,17 @@ def main(
         commit_msg = s.commit_msg
         logging.debug("-- commit_msg:\n{}".format(textwrap.indent(commit_msg, "   ")))
         if should_unlink:
-            commit_msg = RE_GHSTACK_SOURCE_ID.sub(
+            commit_msg = RE_GHSTACK_COMMENT_ID.sub(
                 "",
-                ghstack.diff.re_pull_request_resolved_w_sp(github_url).sub(
-                    "", commit_msg
+                RE_GHSTACK_SOURCE_ID.sub(
+                    "",
+                    ghstack.diff.re_pull_request_resolved_w_sp(github_url).sub(
+                        "", commit_msg
+                    ),
                 ),
             )
+            # Clean up any extra trailing newlines
+            commit_msg = commit_msg.rstrip() + "\n"
             logging.debug(
                 "-- edited commit_msg:\n{}".format(textwrap.indent(commit_msg, "   "))
             )

--- a/test/unlink/basic.py.test
+++ b/test/unlink/basic.py.test
@@ -30,17 +30,11 @@ if is_direct():
 
             This is commit A
 
-
-
-
             * 2193fd2 Initial 2
 
         [O] #503 Commit B (gh/ezyang/4/head -> gh/ezyang/3/head)
 
             This is commit B
-
-
-
 
             * ce2fa9b Initial 2
 

--- a/test/unlink/strip_comment_id.py.test
+++ b/test/unlink/strip_comment_id.py.test
@@ -1,0 +1,28 @@
+from ghstack.test_prelude import *
+
+init_test()
+
+commit("A")
+commit("B")
+gh_submit("Initial 1")
+
+# Verify ghstack-comment-id is present before unlink (direct mode only)
+if is_direct():
+    log = git("log", "--format=%B", "HEAD~2..HEAD")
+    assert "ghstack-comment-id:" in log, "expected ghstack-comment-id before unlink"
+
+gh_unlink()
+
+# After unlink, ghstack-comment-id should be stripped from all commits
+log = git("log", "--format=%B", "HEAD~2..HEAD")
+assert "ghstack-comment-id:" not in log, (
+    "ghstack-comment-id should be stripped after unlink, got:\n" + log
+)
+assert "ghstack-source-id:" not in log, (
+    "ghstack-source-id should be stripped after unlink, got:\n" + log
+)
+assert "Pull-Request:" not in log, (
+    "Pull-Request should be stripped after unlink, got:\n" + log
+)
+
+ok()


### PR DESCRIPTION
The unlink command was only removing ghstack-source-id and Pull Request
Resolved trailers, leaving behind ghstack-comment-id and extra blank
lines in the commit message. Now all ghstack-related metadata is
cleaned up.