### PR TITLE
Support non-git SSH usernames in remote URL parsing (#360)

### DIFF
--- a/src/ghstack/github_utils.py
+++ b/src/ghstack/github_utils.py
@@ -32,7 +32,10 @@ async def get_github_repo_name_with_owner(
     # where commits will actually be pushed to
     remote_url = await sh.agit("remote", "get-url", "--push", remote_name)
     while True:
-        match = r"^git@{github_url}:/?([^/]+)/(.+?)(?:\.git)?$".format(
+        # The SSH user can be "git" (e.g. git@github.com:owner/repo.git) or an
+        # arbitrary identity such as the org-scoped deploy user GitHub now hands
+        # out (e.g. org-21003710@github.com:owner/repo.git), so match any user.
+        match = r"^[^@]+@{github_url}:/?([^/]+)/(.+?)(?:\.git)?$".format(
             github_url=github_url
         )
         m = re.match(match, remote_url)
@@ -175,7 +178,9 @@ GitHubPullRequestParams = TypedDict(
 def _normalize_remote_url(remote_url: str) -> str:
     """Convert SSH remote URL to HTTPS format, strip .git suffix."""
     # git@github.com:owner/repo.git -> https://github.com/owner/repo
-    m = re.match(r"^git@([^:]+):/?(.+?)(?:\.git)?$", remote_url)
+    # The SSH user may be "git" or an org-scoped identity such as
+    # org-21003710@github.com:owner/repo.git, so match any user.
+    m = re.match(r"^[^@]+@([^:]+):/?(.+?)(?:\.git)?$", remote_url)
     if m:
         return f"https://{m.group(1)}/{m.group(2)}"
     return re.sub(r"\.git$", "", remote_url)

--- a/test/github_utils/get_repo_name_with_owner.py.test
+++ b/test/github_utils/get_repo_name_with_owner.py.test
@@ -70,3 +70,21 @@ assert_eq(
     ),
     {"owner": "ezyang", "name": "ghstack"},
 )
+# The classic "git" SSH user.
+await git("remote", "add", "ssh-git-user", "git@github.com:pytorch/pytorch.git")
+assert_eq(
+    await ghstack.github_utils.get_github_repo_name_with_owner(
+        sh=sh, github_url="github.com", remote_name="ssh-git-user"
+    ),
+    {"owner": "pytorch", "name": "pytorch"},
+)
+# The newer org-scoped SSH user (see ezyang/ghstack#360).
+await git(
+    "remote", "add", "ssh-org-user", "org-21003710@github.com:pytorch/pytorch.git"
+)
+assert_eq(
+    await ghstack.github_utils.get_github_repo_name_with_owner(
+        sh=sh, github_url="github.com", remote_name="ssh-org-user"
+    ),
+    {"owner": "pytorch", "name": "pytorch"},
+)


### PR DESCRIPTION
Fixes #360

## Problem

`ghstack submit` fails on repos whose `origin` push URL uses an org-scoped SSH deploy user that GitHub now hands out, e.g.:

```
RuntimeError: Couldn't determine repo owner and name from url: org-21003710@github.com:pytorch/pytorch.git
```

The remote-URL regexes hardcoded the `git` SSH username (`^git@...`), so the new `org-<id>@github.com:owner/repo.git` format didn't match.

## Fix

Match any SSH user (`^[^@]+@...`) in both:

- `get_github_repo_name_with_owner` (the function in the issue traceback)
- `_normalize_remote_url` (used to reconstruct PR URLs from a bare PR number), which had the same hardcoded `git@`

## Tests

Added cases to `test/github_utils/get_repo_name_with_owner.py.test` covering **both** the classic `git@github.com:...` and the new `org-21003710@github.com:...` SSH username formats.

Verified the `github_utils` test passes and `black`/`flake8` on `src/ghstack/` are clean.